### PR TITLE
Governed tracing phase1 foundation + planning docs

### DIFF
--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -130,3 +130,11 @@ Behavior:
 - DM events map to one persistent Agent Zero chat per Slack user.
 - Mention events map to one persistent Agent Zero chat per Slack thread.
 - Context mapping is persisted at `usr/slack/socket_context_map.json`.
+
+## Tracing And Training Docs
+
+- PRD: `docs/governance/tracing-prd.md`
+- Success metrics: `docs/governance/tracing-success-metrics.md`
+- Phase 1 (foundation): `docs/governance/tracing-phase-1-foundation.md`
+- Phase 2 (curation): `docs/governance/tracing-phase-2-curation.md`
+- Phase 3 (training ops): `docs/governance/tracing-phase-3-training-ops.md`

--- a/docs/governance/tracing-phase-1-foundation.md
+++ b/docs/governance/tracing-phase-1-foundation.md
@@ -1,0 +1,34 @@
+# Tracing Phase 1: Foundation (2 Weeks)
+
+## Goal
+Ship minimum viable compliant tracing with deterministic event contracts.
+
+## Scope
+- Event taxonomy and enums (`v1`)
+- Postgres audit tables (`actors`, `audit_events`, `policy_decisions`)
+- Event emission SDK (single shared module)
+- Secrets redaction + fail-closed ingestion guard
+- First 10 high-value events in governed runtime
+
+## Deliverables
+- DDL migrations and tests
+- Event schema validation tests
+- Basic audit queries and smoke checks
+
+## Commit Plan
+1. `feat(governance): add canonical event enums and schema contracts`
+2. `feat(governance): add audit ledger DDL and migrations`
+3. `feat(governance): add fail-closed redaction and secret scan gate`
+4. `feat(governance): emit v1 governed runtime audit events`
+5. `test(governance): add schema and audit coverage tests`
+
+## PR Plan
+- PR-1: Event contracts + DDL
+- PR-2: Redaction/secrets fail-closed pipeline
+- PR-3: Runtime instrumentation + tests
+
+## Exit Criteria
+- Complete actor attribution for governed events
+- Zero persisted secret payloads
+- Audit query pack passes in CI
+

--- a/docs/governance/tracing-phase-2-curation.md
+++ b/docs/governance/tracing-phase-2-curation.md
@@ -1,0 +1,34 @@
+# Tracing Phase 2: Data Curation And Dataset Pipeline (2-3 Weeks)
+
+## Goal
+Convert governed traces into reproducible, consent-aware training/eval datasets.
+
+## Scope
+- Consent enforcement in exports (`audit_only|eval_allowed|training_allowed`)
+- Episode builder (`run_id` -> canonical JSONL rows)
+- Deterministic quality scoring (`train_eligible`, `gold`)
+- Dataset lineage metadata and version tags
+
+## Deliverables
+- Export CLI/service for dataset generation
+- Quality scorer module + thresholds
+- Dataset manifest format and lineage tests
+- Retention and deletion handling for training artifacts
+
+## Commit Plan
+1. `feat(dataset): add consent-aware export filters`
+2. `feat(dataset): add episode builder for governed runs`
+3. `feat(dataset): add quality scoring and labels`
+4. `feat(dataset): add lineage metadata and version manifests`
+5. `test(dataset): add consent and lineage regression tests`
+
+## PR Plan
+- PR-1: Consent and export filter layer
+- PR-2: Episode builder + scorer
+- PR-3: Lineage + versioning + tests
+
+## Exit Criteria
+- 100% consent filter accuracy in test suite
+- Reproducible dataset build from same input window
+- Training yield dashboard available (`runs -> eligible -> gold`)
+

--- a/docs/governance/tracing-phase-3-training-ops.md
+++ b/docs/governance/tracing-phase-3-training-ops.md
@@ -1,0 +1,34 @@
+# Tracing Phase 3: Training And Evaluation Ops (3-4 Weeks)
+
+## Goal
+Operationalize small-model adaptation loop using governed datasets.
+
+## Scope
+- Training trigger service (volume, drift, quality thresholds)
+- Eval harness (tool validity, policy adherence, outcome quality)
+- Canary rollout + rollback gates
+- Adapter/model registry metadata for per-task families
+
+## Deliverables
+- Automated training trigger job
+- Evaluation suite and scoring reports
+- Promotion policy for candidate adapters
+- Rollback automation tied to runtime regressions
+
+## Commit Plan
+1. `feat(training): add trigger criteria service and schedules`
+2. `feat(eval): add governed eval harness and benchmark suite`
+3. `feat(release): add adapter promotion and rollback gates`
+4. `feat(observability): add training lifecycle events and dashboards`
+5. `test(training): add canary/rollback policy tests`
+
+## PR Plan
+- PR-1: Triggering + training metadata plumbing
+- PR-2: Eval harness + baseline reports
+- PR-3: Promotion/canary/rollback automation
+
+## Exit Criteria
+- Automated trigger emits candidate training jobs with audit trail
+- Candidate adapters gated by deterministic eval thresholds
+- Canary rollback proven in staging drill
+

--- a/docs/governance/tracing-prd.md
+++ b/docs/governance/tracing-prd.md
@@ -1,0 +1,56 @@
+# Governed Tracing And Training PRD
+
+## Objective
+Build a governed-mode tracing and data pipeline that supports:
+- Compliance-grade audit trail (`who changed what, when, why`)
+- High-quality training/eval dataset generation from normal usage
+- Reliable fine-tuning/adapters path for small local models (`<=14B`)
+
+## Scope
+In scope:
+- Canonical event schema + taxonomy
+- Postgres audit ledger (append-only + integrity chain)
+- OTel instrumentation conventions for governed runtime and tools
+- Data curation pipeline and training eligibility labeling
+
+Out of scope (v1):
+- Multi-tenant SaaS shared-RLS model
+- Full automated model training orchestration
+- Advanced policy simulation sandbox
+
+## Requirements
+1. Security and compliance
+- Never persist raw secrets in any sink.
+- Every decision/action is actor-attributed and timestamped.
+- Tamper-evident event chain per run.
+
+2. Runtime reliability
+- Deterministic event taxonomy and schema validation.
+- Governed policy decisions captured as first-class events.
+- Tool contract results captured for every tool invocation.
+
+3. Data flywheel
+- Per-tenant consent scopes: `audit_only|eval_allowed|training_allowed`.
+- Deterministic quality scoring (`train_eligible`, `gold`).
+- Dataset lineage from dataset row back to event IDs.
+
+## Primary Users
+- Operator/compliance reviewer
+- Platform engineer
+- ML engineer (dataset + adapter training)
+
+## Deliverables
+- Event schema and enums
+- Audit DDL and ingestion library
+- Phase-based rollout docs and dashboards
+
+## Risks
+- Over-collection of sensitive data
+- Schema drift across services
+- Low-quality datasets from unfiltered traces
+
+## Acceptance Criteria
+- Can answer: who approved/changed/ran what, when, and why.
+- Can build reproducible dataset versions with explicit consent filtering.
+- Can compute and track training yield over time.
+

--- a/docs/governance/tracing-success-metrics.md
+++ b/docs/governance/tracing-success-metrics.md
@@ -1,0 +1,39 @@
+# Governed Tracing Success Metrics
+
+## KPI Groups
+## 1) Compliance And Audit
+- `event_coverage_rate` >= 95%: governed runs with complete required event set.
+- `actor_attribution_rate` = 100%: events with valid `actor_id` and `actor_type`.
+- `secret_leak_persisted_count` = 0: persisted payloads flagged with unredacted secrets.
+- `audit_query_sla_p95` <= 3s: p95 response for key audit queries.
+
+## 2) Runtime Reliability
+- `tool_contract_pass_rate` >= 98% on governed production runs.
+- `policy_decision_capture_rate` = 100% for governed tool calls.
+- `schema_validation_fail_rate` <= 1% (excluding synthetic tests).
+- `mean_retry_count` trending down release-over-release.
+
+## 3) Data Flywheel Quality
+- `train_eligible_yield` >= 30% of completed governed runs.
+- `gold_yield` >= 10% of completed governed runs.
+- `lineage_completeness` = 100%: dataset rows contain source event IDs.
+- `consent_filter_accuracy` = 100% in dataset export tests.
+
+## 4) Model Improvement Readiness
+- `json_tool_call_validity` improvement target: +10% over baseline.
+- `policy_violation_rate` non-increasing after model updates.
+- `approval_reject_rate` non-increasing on target task families.
+
+## Operational Dashboards
+- Audit integrity and attribution dashboard
+- Tool contract and policy outcome dashboard
+- Training yield funnel (runs -> eligible -> gold)
+- Drift and retraining trigger dashboard
+
+## Release Gates
+- Block release if:
+  - `secret_leak_persisted_count > 0`
+  - `policy_decision_capture_rate < 100%`
+  - `consent_filter_accuracy < 100%`
+  - Critical audit query checks fail
+

--- a/python/governance_runtime/audit_events.py
+++ b/python/governance_runtime/audit_events.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+
+SCHEMA_VERSION = "1.0.0"
+TAXONOMY_VERSION = "2026.02.18"
+
+DEFAULT_TENANT_ID = "tenant_default"
+DEFAULT_DEPLOYMENT_ID = "deployment_default"
+DEFAULT_ENVIRONMENT = "prod"
+DEFAULT_CONSENT_SCOPE = "audit_only"
+DEFAULT_ACTOR_ID = "actor_agent_runtime"
+DEFAULT_ACTOR_TYPE = "agent"
+
+_REDACTED_SECRET = "[REDACTED_SECRET]"
+_REDACTED_PII = "[REDACTED_PII]"
+_INITIAL_CHAIN_HASH = "sha256:0"
+
+_SECRET_KEYS = {
+    "token",
+    "access_token",
+    "refresh_token",
+    "authorization",
+    "api_key",
+    "apikey",
+    "password",
+    "secret",
+    "client_secret",
+    "private_key",
+    "cookie",
+    "session",
+}
+
+_SECRET_PATTERNS = [
+    re.compile(r"(?i)\bxox[baprs]-[a-z0-9-]{10,}\b"),
+    re.compile(r"(?i)\bghp_[a-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bgithub_pat_[a-z0-9_]{20,}\b"),
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._\-]{20,}\b"),
+]
+
+_EMAIL_PATTERN = re.compile(r"(?i)\b[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}\b")
+
+
+@dataclass
+class SanitizationResult:
+    payload: dict[str, Any]
+    contains_secrets: bool
+    contains_pii: bool
+    redaction_ratio: float
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sanitize_scalar(value: Any, key_hint: str | None) -> tuple[Any, bool, bool, int]:
+    if isinstance(value, str):
+        key_l = (key_hint or "").lower().strip()
+        if key_l in _SECRET_KEYS:
+            return _REDACTED_SECRET, True, False, 1
+
+        for pattern in _SECRET_PATTERNS:
+            if pattern.search(value):
+                return _REDACTED_SECRET, True, False, 1
+
+        if _EMAIL_PATTERN.search(value):
+            redacted = _EMAIL_PATTERN.sub(_REDACTED_PII, value)
+            return redacted, False, True, 1
+    return value, False, False, 0
+
+
+def _sanitize_value(value: Any, key_hint: str | None = None) -> tuple[Any, bool, bool, int, int]:
+    # Returns: value, contains_secret, contains_pii, redactions, total_fields
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        secret = False
+        pii = False
+        redactions = 0
+        total = 0
+        for k, v in value.items():
+            sanitized, s, p, r, t = _sanitize_value(v, str(k))
+            out[str(k)] = sanitized
+            secret = secret or s
+            pii = pii or p
+            redactions += r
+            total += t
+        return out, secret, pii, redactions, total
+
+    if isinstance(value, list):
+        out_list: list[Any] = []
+        secret = False
+        pii = False
+        redactions = 0
+        total = 0
+        for item in value:
+            sanitized, s, p, r, t = _sanitize_value(item, key_hint)
+            out_list.append(sanitized)
+            secret = secret or s
+            pii = pii or p
+            redactions += r
+            total += t
+        return out_list, secret, pii, redactions, total
+
+    sanitized, s, p, r = _sanitize_scalar(value, key_hint)
+    return sanitized, s, p, r, 1
+
+
+def sanitize_payload(payload: dict[str, Any]) -> SanitizationResult:
+    if not isinstance(payload, dict):
+        payload = {"value": payload}
+    sanitized, contains_secrets, contains_pii, redactions, total = _sanitize_value(payload)
+    ratio = float(redactions) / float(max(1, total))
+    return SanitizationResult(
+        payload=sanitized if isinstance(sanitized, dict) else {"value": sanitized},
+        contains_secrets=contains_secrets,
+        contains_pii=contains_pii,
+        redaction_ratio=round(ratio, 6),
+    )
+
+
+def build_audit_event(
+    *,
+    base_event: dict[str, Any],
+    tenant_id: str = DEFAULT_TENANT_ID,
+    deployment_id: str = DEFAULT_DEPLOYMENT_ID,
+    environment: str = DEFAULT_ENVIRONMENT,
+    actor_id: str = DEFAULT_ACTOR_ID,
+    actor_type: str = DEFAULT_ACTOR_TYPE,
+    consent_scope: str = DEFAULT_CONSENT_SCOPE,
+    run_id: str,
+    sequence_number: int,
+    prev_event_hash: str = _INITIAL_CHAIN_HASH,
+    trace_id: str | None = None,
+    span_id: str | None = None,
+    parent_span_id: str | None = None,
+) -> dict[str, Any]:
+    observed_at = str(base_event.get("created_at") or dt.datetime.now(dt.timezone.utc).isoformat())
+    raw_payload = dict(base_event)
+    sanitized = sanitize_payload(raw_payload)
+
+    payload_json = {"suppressed": True} if sanitized.contains_secrets else sanitized.payload
+    payload_hash = sha256_text(_stable_json(payload_json))
+    chain_input = _stable_json(
+        {
+            "prev_event_hash": prev_event_hash,
+            "payload_hash": payload_hash,
+            "event_type": str(base_event.get("type", "governance.event")),
+            "sequence_number": sequence_number,
+            "run_id": run_id,
+        }
+    )
+    event_hash = sha256_text(chain_input)
+
+    return {
+        "event_id": str(uuid.uuid4()),
+        "schema_version": SCHEMA_VERSION,
+        "taxonomy_version": TAXONOMY_VERSION,
+        "tenant_id": tenant_id,
+        "deployment_id": deployment_id,
+        "environment": environment,
+        "run_id": run_id,
+        "sequence_number": int(sequence_number),
+        "event_type": str(base_event.get("type", "governance.event")),
+        "observed_at": observed_at,
+        "recorded_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "actor_id": actor_id,
+        "actor_type": actor_type,
+        "subject_kind": str(base_event.get("subject_kind") or ""),
+        "subject_name": str(base_event.get("tool_name") or ""),
+        "subject_version": str(base_event.get("subject_version") or ""),
+        "contract_id": str(base_event.get("contract_id") or ""),
+        "payload_json": payload_json,
+        "payload_hash": payload_hash,
+        "contains_secrets": sanitized.contains_secrets,
+        "contains_pii": sanitized.contains_pii,
+        "redaction_ratio": sanitized.redaction_ratio,
+        "consent_scope": consent_scope,
+        "integrity_chain_id": f"{tenant_id}:{run_id}",
+        "prev_event_hash": prev_event_hash,
+        "event_hash": event_hash,
+    }

--- a/python/governance_runtime/migrations/002_governance_audit_schema.sql
+++ b/python/governance_runtime/migrations/002_governance_audit_schema.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS governance.actors (
+  actor_id TEXT PRIMARY KEY,
+  actor_type TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  auth_subject TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  disabled_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS governance.audit_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id TEXT NOT NULL UNIQUE,
+  schema_version TEXT NOT NULL,
+  taxonomy_version TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  deployment_id TEXT NOT NULL,
+  environment TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  event_type TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  trace_id TEXT,
+  span_id TEXT,
+  parent_span_id TEXT,
+  actor_id TEXT NOT NULL REFERENCES governance.actors(actor_id),
+  actor_type TEXT NOT NULL,
+  subject_kind TEXT,
+  subject_name TEXT,
+  subject_version TEXT,
+  contract_id TEXT,
+  payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  payload_hash TEXT NOT NULL,
+  contains_secrets BOOLEAN NOT NULL DEFAULT FALSE,
+  contains_pii BOOLEAN NOT NULL DEFAULT FALSE,
+  redaction_ratio REAL NOT NULL DEFAULT 0.0,
+  consent_scope TEXT NOT NULL DEFAULT 'audit_only',
+  integrity_chain_id TEXT NOT NULL,
+  prev_event_hash TEXT NOT NULL,
+  event_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, run_id, sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS ix_governance_audit_events_run
+  ON governance.audit_events(tenant_id, run_id, sequence_number);
+CREATE INDEX IF NOT EXISTS ix_governance_audit_events_type_ts
+  ON governance.audit_events(event_type, observed_at);
+CREATE INDEX IF NOT EXISTS ix_governance_audit_events_event_id
+  ON governance.audit_events(event_id);
+
+CREATE TABLE IF NOT EXISTS governance.policy_decisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  policy_name TEXT NOT NULL,
+  policy_version TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  reason_codes TEXT[] NOT NULL DEFAULT '{}',
+  observed_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_governance_policy_decisions_run
+  ON governance.policy_decisions(tenant_id, run_id, sequence_number);

--- a/python/governance_runtime/repos.py
+++ b/python/governance_runtime/repos.py
@@ -6,6 +6,15 @@ import threading
 import uuid
 from typing import Any
 
+from python.governance_runtime.audit_events import (
+    DEFAULT_ACTOR_ID,
+    DEFAULT_ACTOR_TYPE,
+    DEFAULT_CONSENT_SCOPE,
+    DEFAULT_DEPLOYMENT_ID,
+    DEFAULT_ENVIRONMENT,
+    DEFAULT_TENANT_ID,
+    build_audit_event,
+)
 from python.governance_runtime.db import connection, is_postgres_available
 
 
@@ -61,6 +70,70 @@ CREATE TABLE IF NOT EXISTS governance.approvals (
 
 CREATE INDEX IF NOT EXISTS ix_governance_approvals_project_status
   ON governance.approvals(project_name, status);
+
+CREATE TABLE IF NOT EXISTS governance.actors (
+  actor_id TEXT PRIMARY KEY,
+  actor_type TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  auth_subject TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  disabled_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS governance.audit_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id TEXT NOT NULL UNIQUE,
+  schema_version TEXT NOT NULL,
+  taxonomy_version TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  deployment_id TEXT NOT NULL,
+  environment TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  event_type TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  trace_id TEXT,
+  span_id TEXT,
+  parent_span_id TEXT,
+  actor_id TEXT NOT NULL REFERENCES governance.actors(actor_id),
+  actor_type TEXT NOT NULL,
+  subject_kind TEXT,
+  subject_name TEXT,
+  subject_version TEXT,
+  contract_id TEXT,
+  payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  payload_hash TEXT NOT NULL,
+  contains_secrets BOOLEAN NOT NULL DEFAULT FALSE,
+  contains_pii BOOLEAN NOT NULL DEFAULT FALSE,
+  redaction_ratio REAL NOT NULL DEFAULT 0.0,
+  consent_scope TEXT NOT NULL DEFAULT 'audit_only',
+  integrity_chain_id TEXT NOT NULL,
+  prev_event_hash TEXT NOT NULL,
+  event_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, run_id, sequence_number)
+);
+
+CREATE INDEX IF NOT EXISTS ix_governance_audit_events_run ON governance.audit_events(tenant_id, run_id, sequence_number);
+CREATE INDEX IF NOT EXISTS ix_governance_audit_events_type_ts ON governance.audit_events(event_type, observed_at);
+CREATE INDEX IF NOT EXISTS ix_governance_audit_events_event_id ON governance.audit_events(event_id);
+
+CREATE TABLE IF NOT EXISTS governance.policy_decisions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  policy_name TEXT NOT NULL,
+  policy_version TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  reason_codes TEXT[] NOT NULL DEFAULT '{}',
+  observed_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_governance_policy_decisions_run ON governance.policy_decisions(tenant_id, run_id, sequence_number);
 """
 
 
@@ -190,6 +263,111 @@ class GovernancePostgresRepo:
                     VALUES (%s, %s, %s, %s, %s::jsonb)
                     """,
                     (run_id, thread_id, sequence_number, event_type, payload_json),
+                )
+                actor_id = str(event.get("actor_id") or os.environ.get("A0_ACTOR_ID", DEFAULT_ACTOR_ID))
+                actor_type = str(event.get("actor_type") or os.environ.get("A0_ACTOR_TYPE", DEFAULT_ACTOR_TYPE))
+                tenant_id = str(event.get("tenant_id") or os.environ.get("A0_TENANT_ID", DEFAULT_TENANT_ID))
+                deployment_id = str(
+                    event.get("deployment_id") or os.environ.get("A0_DEPLOYMENT_ID", DEFAULT_DEPLOYMENT_ID)
+                )
+                environment = str(event.get("environment") or os.environ.get("A0_ENVIRONMENT", DEFAULT_ENVIRONMENT))
+                consent_scope = str(event.get("consent_scope") or DEFAULT_CONSENT_SCOPE)
+                audit_run_id = str(run_id or event.get("thread_id") or "governance-unscoped")
+
+                cur.execute(
+                    """
+                    INSERT INTO governance.actors (actor_id, actor_type, display_name)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (actor_id) DO NOTHING
+                    """,
+                    (actor_id, actor_type, actor_id),
+                )
+
+                cur.execute(
+                    """
+                    SELECT sequence_number, event_hash
+                    FROM governance.audit_events
+                    WHERE tenant_id = %s AND run_id = %s
+                    ORDER BY sequence_number DESC
+                    LIMIT 1
+                    """,
+                    (tenant_id, audit_run_id),
+                )
+                prev = cur.fetchone()
+                prev_seq = int(prev[0]) if prev else 0
+                prev_hash = str(prev[1]) if prev else "sha256:0"
+
+                try:
+                    explicit_seq = int(sequence_number) if sequence_number is not None else None
+                except Exception:
+                    explicit_seq = None
+                audit_seq = explicit_seq if explicit_seq and explicit_seq > 0 else prev_seq + 1
+
+                audit_event = build_audit_event(
+                    base_event=event,
+                    tenant_id=tenant_id,
+                    deployment_id=deployment_id,
+                    environment=environment,
+                    actor_id=actor_id,
+                    actor_type=actor_type,
+                    consent_scope=consent_scope,
+                    run_id=audit_run_id,
+                    sequence_number=audit_seq,
+                    prev_event_hash=prev_hash,
+                    trace_id=str(event.get("trace_id") or "") or None,
+                    span_id=str(event.get("span_id") or "") or None,
+                    parent_span_id=str(event.get("parent_span_id") or "") or None,
+                )
+
+                cur.execute(
+                    """
+                    INSERT INTO governance.audit_events (
+                      event_id, schema_version, taxonomy_version, tenant_id, deployment_id, environment,
+                      run_id, sequence_number, event_type, observed_at, recorded_at,
+                      trace_id, span_id, parent_span_id,
+                      actor_id, actor_type, subject_kind, subject_name, subject_version, contract_id,
+                      payload_json, payload_hash, contains_secrets, contains_pii, redaction_ratio,
+                      consent_scope, integrity_chain_id, prev_event_hash, event_hash
+                    ) VALUES (
+                      %s,%s,%s,%s,%s,%s,
+                      %s,%s,%s,%s::timestamptz,%s::timestamptz,
+                      %s,%s,%s,
+                      %s,%s,%s,%s,%s,%s,
+                      %s::jsonb,%s,%s,%s,%s,
+                      %s,%s,%s,%s
+                    )
+                    """,
+                    (
+                        audit_event["event_id"],
+                        audit_event["schema_version"],
+                        audit_event["taxonomy_version"],
+                        audit_event["tenant_id"],
+                        audit_event["deployment_id"],
+                        audit_event["environment"],
+                        audit_event["run_id"],
+                        audit_event["sequence_number"],
+                        audit_event["event_type"],
+                        audit_event["observed_at"],
+                        audit_event["recorded_at"],
+                        audit_event["trace_id"],
+                        audit_event["span_id"],
+                        audit_event["parent_span_id"],
+                        audit_event["actor_id"],
+                        audit_event["actor_type"],
+                        audit_event["subject_kind"],
+                        audit_event["subject_name"],
+                        audit_event["subject_version"],
+                        audit_event["contract_id"],
+                        json.dumps(audit_event["payload_json"], sort_keys=True, default=str),
+                        audit_event["payload_hash"],
+                        bool(audit_event["contains_secrets"]),
+                        bool(audit_event["contains_pii"]),
+                        float(audit_event["redaction_ratio"]),
+                        audit_event["consent_scope"],
+                        audit_event["integrity_chain_id"],
+                        audit_event["prev_event_hash"],
+                        audit_event["event_hash"],
+                    ),
                 )
             conn.commit()
 

--- a/python/helpers/governance_gate.py
+++ b/python/helpers/governance_gate.py
@@ -91,6 +91,27 @@ def _append_governance_event(event: dict[str, Any]) -> None:
         f.write(_stable_json(event) + "\n")
 
 
+def _emit_governance_event(agent: Any, event: dict[str, Any]) -> None:
+    context = getattr(agent, "context", None)
+    enriched = dict(event)
+    if "created_at" not in enriched:
+        enriched["created_at"] = _now_iso()
+    if context is not None:
+        context_id = str(getattr(context, "id", "") or "")
+        if context_id:
+            enriched.setdefault("thread_id", context_id)
+            enriched.setdefault("run_id", context_id)
+        seq_no = getattr(context, "message_id", None)
+        if seq_no is not None:
+            try:
+                enriched.setdefault("sequence_number", int(seq_no))
+            except Exception:
+                pass
+    enriched.setdefault("actor_id", "actor_policy_engine")
+    enriched.setdefault("actor_type", "policy")
+    _append_governance_event(enriched)
+
+
 def _load_project_governance(agent: Any) -> dict[str, Any]:
     from python.helpers import projects
 
@@ -388,7 +409,7 @@ def _persist_approval_if_needed(agent: Any, *, project_name: str, tool_name: str
         "tool_call_hash": tool_call_hash,
         "tool_args": _sanitize_tool_args(tool_args),
     }
-    _append_governance_event(event)
+    _emit_governance_event(agent, event)
 
     context = getattr(agent, "context", None)
     if context is not None:
@@ -505,6 +526,19 @@ def evaluate_tool_gate(agent: Any, tool_name: str, tool_args: dict[str, Any] | N
         elif status == "denied":
             decision = "deny"
 
+    policy_event = {
+        "type": "policy.check.decision",
+        "project_name": project_name,
+        "tool_name": tool_name,
+        "risk": risk,
+        "decision": decision,
+        "readonly_terminal": is_readonly_terminal,
+        "tool_call_hash": tool_call_hash,
+        "unknown_tool": unknown_tool,
+        "mode": str(policy.get("mode", "standard")),
+    }
+    _emit_governance_event(agent, policy_event)
+
     if decision == "deny":
         try:
             agent.context.log.log(
@@ -608,7 +642,7 @@ def resolve_approval(agent: Any, approval_id: str, decision: str, rationale: str
         "risk": (payload or {}).get("risk"),
         "tool_call_hash": (payload or {}).get("tool_call_hash"),
     }
-    _append_governance_event(event)
+    _emit_governance_event(agent, event)
 
     context = getattr(agent, "context", None)
     if context is not None:

--- a/tests/test_governance_audit_events.py
+++ b/tests/test_governance_audit_events.py
@@ -1,0 +1,53 @@
+from python.governance_runtime.audit_events import build_audit_event, sanitize_payload
+
+
+def test_sanitize_payload_redacts_secrets_and_detects_pii():
+    payload = {
+        "tool_name": "slack:post_dm",
+        "token": "xoxb-123456789012-abc123secret",
+        "text": "Email me at botsheldon7@gmail.com",
+    }
+    result = sanitize_payload(payload)
+    assert result.contains_secrets is True
+    assert result.contains_pii is True
+    assert result.payload["token"] == "[REDACTED_SECRET]"
+    assert "[REDACTED_PII]" in result.payload["text"]
+
+
+def test_build_audit_event_suppresses_payload_when_secret_detected():
+    base_event = {
+        "type": "tool.call.requested",
+        "tool_name": "gh:pr_create",
+        "tool_args": {"token": "ghp_1234567890abcdefghijklmnop"},
+    }
+    audit = build_audit_event(
+        base_event=base_event,
+        run_id="run-1",
+        sequence_number=1,
+        prev_event_hash="sha256:0",
+    )
+    assert audit["contains_secrets"] is True
+    assert audit["payload_json"] == {"suppressed": True}
+    assert audit["event_hash"].startswith("sha256:")
+
+
+def test_build_audit_event_hash_chain_changes_with_prev_hash():
+    base_event = {
+        "type": "policy.check.decision",
+        "tool_name": "code_execution_tool",
+        "decision": "allow",
+    }
+    first = build_audit_event(
+        base_event=base_event,
+        run_id="run-2",
+        sequence_number=1,
+        prev_event_hash="sha256:0",
+    )
+    second = build_audit_event(
+        base_event=base_event,
+        run_id="run-2",
+        sequence_number=2,
+        prev_event_hash=first["event_hash"],
+    )
+    assert second["prev_event_hash"] == first["event_hash"]
+    assert second["event_hash"] != first["event_hash"]

--- a/tests/test_governance_input.py
+++ b/tests/test_governance_input.py
@@ -18,6 +18,8 @@ class _DummyContext:
     def __init__(self):
         self.paused = False
         self.log = _DummyLog()
+        self.id = "ctx_test_1"
+        self.message_id = 1
 
 
 class _DummyAgent:
@@ -221,3 +223,22 @@ def test_gh_write_methods_require_approval(monkeypatch):
     assert result["risk"] == "high"
     assert result["decision"] == "require_approval"
     assert agent.context.paused is True
+
+
+def test_policy_check_decision_event_is_emitted(monkeypatch):
+    from python.helpers import governance_gate, projects
+
+    events: list[dict] = []
+
+    monkeypatch.setattr(projects, "get_context_project_name", lambda _ctx: "p1")
+    monkeypatch.setattr(projects, "load_basic_project_data", lambda _name: _policy(True, "standard"))
+    monkeypatch.setattr(governance_gate, "_append_governance_event", lambda event: events.append(event))
+
+    agent = _DummyAgent()
+    evaluate_tool_gate(agent, "search_engine", {"query": "agent tracing"})
+
+    assert any(e.get("type") == "policy.check.decision" for e in events)
+    policy_event = next(e for e in events if e.get("type") == "policy.check.decision")
+    assert policy_event.get("tool_name") == "search_engine"
+    assert policy_event.get("decision") == "allow"
+    assert policy_event.get("thread_id") == "ctx_test_1"

--- a/tests/test_governance_persistence_db.py
+++ b/tests/test_governance_persistence_db.py
@@ -73,7 +73,9 @@ def test_postgres_backend_writes_repo_only_when_dual_write_disabled(monkeypatch,
 
     assert result["decision"] == "require_approval"
     assert len(fake_repo.upsert_calls) == 1
-    assert len(fake_repo.events) == 1
+    event_types = [str(e.get("type", "")) for e in fake_repo.events]
+    assert "approval.requested" in event_types
+    assert "policy.check.decision" in event_types
     assert not (tmp_path / "approvals").exists()
 
 


### PR DESCRIPTION
## Summary
Implements the first slice of the governed tracing plan and adds the planning docs requested.

### Docs (split commits)
- Governance tracing PRD
- Governance tracing success metrics
- Governance phased implementation docs (phase 1/2/3) and README links

### Phase 1 implementation
- Added canonical governance audit event builder:
  - `python/governance_runtime/audit_events.py`
  - deterministic schema/taxonomy versions
  - payload sanitization with secret/PII detection
  - fail-safe secret suppression in audit payloads
  - hash-chain fields (`prev_event_hash`, `event_hash`)
- Extended governance Postgres schema:
  - `governance.actors`
  - `governance.audit_events`
  - `governance.policy_decisions` (foundation table)
  - migration file `002_governance_audit_schema.sql`
- Extended repo write path (`append_event`) to dual-write:
  - existing `governance.events` (backward compatibility)
  - new `governance.audit_events`
- Added deterministic policy decision event emission:
  - `policy.check.decision` emitted from governance gate evaluation

## Validation
All tests run in Docker app container:
- `pytest -q /a0/tests/test_governance_input.py /a0/tests/test_governance_audit_events.py`
- Full custom regression command (CI-style)

Result: `42 passed`

## Notes
This is the Phase 1 foundation slice. Next PR will add stricter event taxonomy enforcement and policy decision persistence rows.
