### PR TITLE
Governance tracing phase1: run/tool-request events

### DIFF
--- a/python/helpers/governance_gate.py
+++ b/python/helpers/governance_gate.py
@@ -18,6 +18,7 @@ from python.governance_runtime.repos import (
 
 GATE_TOKEN_KEY = "__governance_gate_evaluated"
 TOOL_CALL_HASH_KEY = "__governance_tool_call_hash"
+RUN_STARTED_SENT_KEY = "__governance_run_started_emitted"
 
 
 def _now_iso() -> str:
@@ -110,6 +111,26 @@ def _emit_governance_event(agent: Any, event: dict[str, Any]) -> None:
     enriched.setdefault("actor_id", "actor_policy_engine")
     enriched.setdefault("actor_type", "policy")
     _append_governance_event(enriched)
+
+
+def _emit_run_started_once(agent: Any, project_name: str) -> None:
+    if not project_name:
+        return
+    context = getattr(agent, "context", None)
+    if context is None:
+        return
+    marker = getattr(context, RUN_STARTED_SENT_KEY, False)
+    if marker:
+        return
+    setattr(context, RUN_STARTED_SENT_KEY, True)
+    _emit_governance_event(
+        agent,
+        {
+            "type": "run.started",
+            "project_name": project_name,
+            "source": "governance_gate",
+        },
+    )
 
 
 def _load_project_governance(agent: Any) -> dict[str, Any]:
@@ -478,6 +499,8 @@ def evaluate_tool_gate(agent: Any, tool_name: str, tool_args: dict[str, Any] | N
             "tool_call_hash": "",
         }
 
+    _emit_run_started_once(agent, project_name)
+
     risk, unknown_tool = _risk_for_tool(tool_name, args, policy)
     is_readonly_terminal = (
         tool_name == "code_execution_tool"
@@ -508,6 +531,17 @@ def evaluate_tool_gate(agent: Any, tool_name: str, tool_args: dict[str, Any] | N
         )
 
     tool_call_hash = _deterministic_tool_call_hash(project_name, tool_name, args)
+    _emit_governance_event(
+        agent,
+        {
+            "type": "tool.call.requested",
+            "project_name": project_name,
+            "tool_name": tool_name,
+            "tool_call_hash": tool_call_hash,
+            "tool_args": _sanitize_tool_args(args),
+            "mode": str(policy.get("mode", "standard")),
+        },
+    )
     token = f"gov_{tool_call_hash[:20]}"
     approval_id: str | None = None
 

--- a/tests/test_governance_input.py
+++ b/tests/test_governance_input.py
@@ -238,7 +238,25 @@ def test_policy_check_decision_event_is_emitted(monkeypatch):
     evaluate_tool_gate(agent, "search_engine", {"query": "agent tracing"})
 
     assert any(e.get("type") == "policy.check.decision" for e in events)
+    assert any(e.get("type") == "tool.call.requested" for e in events)
+    assert any(e.get("type") == "run.started" for e in events)
     policy_event = next(e for e in events if e.get("type") == "policy.check.decision")
     assert policy_event.get("tool_name") == "search_engine"
     assert policy_event.get("decision") == "allow"
     assert policy_event.get("thread_id") == "ctx_test_1"
+
+
+def test_run_started_is_emitted_once_per_context(monkeypatch):
+    from python.helpers import governance_gate, projects
+
+    events: list[dict] = []
+    monkeypatch.setattr(projects, "get_context_project_name", lambda _ctx: "p1")
+    monkeypatch.setattr(projects, "load_basic_project_data", lambda _name: _policy(True, "standard"))
+    monkeypatch.setattr(governance_gate, "_append_governance_event", lambda event: events.append(event))
+
+    agent = _DummyAgent()
+    evaluate_tool_gate(agent, "search_engine", {"query": "first"})
+    evaluate_tool_gate(agent, "search_engine", {"query": "second"})
+
+    run_started_events = [e for e in events if e.get("type") == "run.started"]
+    assert len(run_started_events) == 1


### PR DESCRIPTION
## Summary
- emit `run.started` once per governed context in `evaluate_tool_gate`
- emit `tool.call.requested` for each governed tool-gate evaluation
- extend governance tests to assert both event types and once-per-context behavior

## Validation
- `./tools/e2e.sh` (Docker CI-equivalent path)
  - result: `24 passed`
