### PR TITLE
Governance tracing: monotonic audit sequence allocation

### DIFF
--- a/python/governance_runtime/repos.py
+++ b/python/governance_runtime/repos.py
@@ -157,6 +157,17 @@ def is_dual_write_enabled() -> bool:
     return _env_flag("GOV_DUAL_WRITE", default=False)
 
 
+def _resolve_audit_sequence_number(prev_seq: int, candidate_sequence: Any) -> int:
+    """Return a monotonic sequence number for audit_events unique key."""
+    try:
+        explicit_seq = int(candidate_sequence) if candidate_sequence is not None else None
+    except Exception:
+        explicit_seq = None
+    if explicit_seq is not None and explicit_seq > prev_seq:
+        return explicit_seq
+    return prev_seq + 1
+
+
 class GovernancePostgresRepo:
     def __init__(self) -> None:
         self._ddl_lock = threading.Lock()
@@ -297,11 +308,7 @@ class GovernancePostgresRepo:
                 prev_seq = int(prev[0]) if prev else 0
                 prev_hash = str(prev[1]) if prev else "sha256:0"
 
-                try:
-                    explicit_seq = int(sequence_number) if sequence_number is not None else None
-                except Exception:
-                    explicit_seq = None
-                audit_seq = explicit_seq if explicit_seq and explicit_seq > 0 else prev_seq + 1
+                audit_seq = _resolve_audit_sequence_number(prev_seq=prev_seq, candidate_sequence=sequence_number)
 
                 audit_event = build_audit_event(
                     base_event=event,

--- a/tests/test_governance_repo_sequence.py
+++ b/tests/test_governance_repo_sequence.py
@@ -1,0 +1,15 @@
+from python.governance_runtime.repos import _resolve_audit_sequence_number
+
+
+def test_sequence_uses_explicit_when_greater_than_previous():
+    assert _resolve_audit_sequence_number(prev_seq=2, candidate_sequence=5) == 5
+
+
+def test_sequence_increments_when_explicit_repeats_or_regresses():
+    assert _resolve_audit_sequence_number(prev_seq=3, candidate_sequence=3) == 4
+    assert _resolve_audit_sequence_number(prev_seq=3, candidate_sequence=2) == 4
+
+
+def test_sequence_increments_when_candidate_missing_or_invalid():
+    assert _resolve_audit_sequence_number(prev_seq=7, candidate_sequence=None) == 8
+    assert _resolve_audit_sequence_number(prev_seq=7, candidate_sequence="not-a-number") == 8


### PR DESCRIPTION
## Summary
- fix governance audit sequence assignment to be monotonic per `(tenant_id, run_id)`
- prevent unique-key collisions in `governance.audit_events` when multiple events share the same candidate sequence
- add focused regression tests for sequence allocation behavior

## Validation
- `./tools/e2e.sh` (Docker CI-equivalent path)
  - result: `24 passed`
