### PR TITLE
Governance tracing: persist policy decision records

### DIFF
--- a/python/governance_runtime/repos.py
+++ b/python/governance_runtime/repos.py
@@ -168,6 +168,39 @@ def _resolve_audit_sequence_number(prev_seq: int, candidate_sequence: Any) -> in
     return prev_seq + 1
 
 
+def _build_policy_decision_record(
+    *,
+    event: dict[str, Any],
+    audit_event: dict[str, Any],
+) -> dict[str, Any] | None:
+    if str(audit_event.get("event_type", "")).strip() != "policy.check.decision":
+        return None
+
+    decision = str(event.get("decision", "")).strip().lower()
+    if decision not in {"allow", "deny", "require_approval", "transform", "redact", "route", "quarantine"}:
+        return None
+
+    reason_codes_raw = event.get("reason_codes")
+    reason_codes: list[str] = []
+    if isinstance(reason_codes_raw, list):
+        reason_codes = [str(x).strip() for x in reason_codes_raw if str(x).strip()]
+
+    policy_name = str(event.get("policy_name", "governance_gate")).strip() or "governance_gate"
+    policy_version = str(event.get("policy_version", "v1")).strip() or "v1"
+
+    return {
+        "event_id": str(audit_event.get("event_id", "")),
+        "tenant_id": str(audit_event.get("tenant_id", "")),
+        "run_id": str(audit_event.get("run_id", "")),
+        "sequence_number": int(audit_event.get("sequence_number", 0)),
+        "policy_name": policy_name,
+        "policy_version": policy_version,
+        "decision": decision,
+        "reason_codes": reason_codes,
+        "observed_at": str(audit_event.get("observed_at", "")),
+    }
+
+
 class GovernancePostgresRepo:
     def __init__(self) -> None:
         self._ddl_lock = threading.Lock()
@@ -376,6 +409,28 @@ class GovernancePostgresRepo:
                         audit_event["event_hash"],
                     ),
                 )
+
+                policy_record = _build_policy_decision_record(event=event, audit_event=audit_event)
+                if policy_record is not None:
+                    cur.execute(
+                        """
+                        INSERT INTO governance.policy_decisions (
+                          event_id, tenant_id, run_id, sequence_number,
+                          policy_name, policy_version, decision, reason_codes, observed_at
+                        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s::timestamptz)
+                        """,
+                        (
+                            policy_record["event_id"],
+                            policy_record["tenant_id"],
+                            policy_record["run_id"],
+                            policy_record["sequence_number"],
+                            policy_record["policy_name"],
+                            policy_record["policy_version"],
+                            policy_record["decision"],
+                            policy_record["reason_codes"],
+                            policy_record["observed_at"],
+                        ),
+                    )
             conn.commit()
 
     def create_run(self, context_id: str, project_name: str | None = None, status: str = "queued") -> str:

--- a/tests/test_governance_repo_policy.py
+++ b/tests/test_governance_repo_policy.py
@@ -1,0 +1,41 @@
+from python.governance_runtime.repos import _build_policy_decision_record
+
+
+def test_build_policy_decision_record_maps_valid_event():
+    event = {
+        "type": "policy.check.decision",
+        "decision": "require_approval",
+        "reason_codes": ["risk.high", "override.none"],
+        "policy_name": "governance_gate",
+        "policy_version": "v1",
+    }
+    audit_event = {
+        "event_id": "evt-1",
+        "event_type": "policy.check.decision",
+        "tenant_id": "tenant-a",
+        "run_id": "run-a",
+        "sequence_number": 12,
+        "observed_at": "2026-02-18T00:00:00+00:00",
+    }
+
+    record = _build_policy_decision_record(event=event, audit_event=audit_event)
+
+    assert record is not None
+    assert record["event_id"] == "evt-1"
+    assert record["tenant_id"] == "tenant-a"
+    assert record["run_id"] == "run-a"
+    assert record["sequence_number"] == 12
+    assert record["decision"] == "require_approval"
+    assert record["reason_codes"] == ["risk.high", "override.none"]
+
+
+def test_build_policy_decision_record_rejects_non_policy_events():
+    event = {"type": "approval.requested", "decision": "allow"}
+    audit_event = {"event_type": "approval.requested"}
+    assert _build_policy_decision_record(event=event, audit_event=audit_event) is None
+
+
+def test_build_policy_decision_record_rejects_unknown_decision():
+    event = {"type": "policy.check.decision", "decision": "maybe"}
+    audit_event = {"event_type": "policy.check.decision"}
+    assert _build_policy_decision_record(event=event, audit_event=audit_event) is None


### PR DESCRIPTION
## Summary
- add mapping helper to build normalized records for `policy.check.decision` events
- persist mapped records into `governance.policy_decisions` alongside audit event writes
- add unit tests for policy-decision mapping rules and validation

## Validation
- `./tools/e2e.sh` (Docker CI-equivalent path)
  - result: `24 passed`
