### PR TITLE
Governance tracing: deterministic policy reason codes

### DIFF
--- a/python/helpers/governance_gate.py
+++ b/python/helpers/governance_gate.py
@@ -570,12 +570,29 @@ def evaluate_tool_gate(agent: Any, tool_name: str, tool_args: dict[str, Any] | N
         elif status == "denied":
             decision = DECISION_DENY
 
+    reason_codes: list[str] = [f"risk.{risk}", f"mode.{str(policy.get('mode', 'standard'))}"]
+    if unknown_tool:
+        reason_codes.append("tool.unknown")
+    if is_readonly_terminal:
+        reason_codes.append("terminal.read_only")
+    if override_decision:
+        reason_codes.append("decision.override")
+    if decision == DECISION_REQUIRE_APPROVAL:
+        reason_codes.append("approval.required")
+    elif decision == DECISION_DENY:
+        reason_codes.append("policy.denied")
+    else:
+        reason_codes.append("policy.allowed")
+
     policy_event = {
         "type": EVENT_POLICY_CHECK_DECISION,
         "project_name": project_name,
         "tool_name": tool_name,
         "risk": risk,
         "decision": decision,
+        "reason_codes": reason_codes,
+        "policy_name": "governance_gate",
+        "policy_version": "v1",
         "readonly_terminal": is_readonly_terminal,
         "tool_call_hash": tool_call_hash,
         "unknown_tool": unknown_tool,

--- a/tests/test_governance_input.py
+++ b/tests/test_governance_input.py
@@ -244,6 +244,10 @@ def test_policy_check_decision_event_is_emitted(monkeypatch):
     assert policy_event.get("tool_name") == "search_engine"
     assert policy_event.get("decision") == "allow"
     assert policy_event.get("thread_id") == "ctx_test_1"
+    assert policy_event.get("policy_name") == "governance_gate"
+    assert policy_event.get("policy_version") == "v1"
+    assert "risk.low" in list(policy_event.get("reason_codes", []))
+    assert "policy.allowed" in list(policy_event.get("reason_codes", []))
 
 
 def test_run_started_is_emitted_once_per_context(monkeypatch):


### PR DESCRIPTION
## Summary
- enrich `policy.check.decision` events with deterministic `reason_codes`
- include `policy_name` and `policy_version` metadata for downstream persistence/analytics
- add assertions in governance gate tests for policy metadata and reason-code population

## Validation
- `./tools/e2e.sh` (Docker CI-equivalent path)
  - result: `24 passed`
