### PR TITLE
feat(governance): fail closed on audit secret scan errors

### DIFF
--- a/python/governance_runtime/audit_events.py
+++ b/python/governance_runtime/audit_events.py
@@ -8,6 +8,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+from python.governance_runtime.event_taxonomy import EVENT_SECURITY_SECRET_SCAN_FAILED
+
 
 SCHEMA_VERSION = "1.0.0"
 TAXONOMY_VERSION = "2026.02.18"
@@ -161,7 +163,19 @@ def build_audit_event(
     event_type = str(base_event.get("type", "governance.event")).strip() or "governance.event"
     observed_at = str(base_event.get("created_at") or dt.datetime.now(dt.timezone.utc).isoformat())
     raw_payload = dict(base_event)
-    sanitized = sanitize_payload(raw_payload)
+    scan_failed = False
+    try:
+        sanitized = sanitize_payload(raw_payload)
+    except Exception:
+        # Fail closed: suppress payload and classify as secret-bearing so no unsafe payload is persisted.
+        scan_failed = True
+        sanitized = SanitizationResult(
+            payload={"suppressed": True},
+            contains_secrets=True,
+            contains_pii=False,
+            redaction_ratio=1.0,
+        )
+        event_type = EVENT_SECURITY_SECRET_SCAN_FAILED
 
     payload_json = {"suppressed": True} if sanitized.contains_secrets else sanitized.payload
     payload_hash = sha256_text(_stable_json(payload_json))
@@ -206,4 +220,5 @@ def build_audit_event(
         "integrity_chain_id": f"{tenant_id}:{run_id}",
         "prev_event_hash": prev_event_hash,
         "event_hash": event_hash,
+        "scan_failed": scan_failed,
     }

--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -6,6 +6,7 @@ EVENT_TOOL_CALL_REQUESTED = "tool.call.requested"
 EVENT_POLICY_CHECK_DECISION = "policy.check.decision"
 EVENT_APPROVAL_REQUESTED = "approval.requested"
 EVENT_APPROVAL_RESOLVED = "approval.resolved"
+EVENT_SECURITY_SECRET_SCAN_FAILED = "security.secret_scan_failed"
 
 DECISION_ALLOW = "allow"
 DECISION_DENY = "deny"

--- a/python/governance_runtime/migrations/002_governance_audit_schema.sql
+++ b/python/governance_runtime/migrations/002_governance_audit_schema.sql
@@ -49,6 +49,24 @@ CREATE INDEX IF NOT EXISTS ix_governance_audit_events_type_ts
 CREATE INDEX IF NOT EXISTS ix_governance_audit_events_event_id
   ON governance.audit_events(event_id);
 
+CREATE OR REPLACE FUNCTION governance.enforce_secret_payload_suppression()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.contains_secrets THEN
+    IF NEW.payload_json <> '{}'::jsonb AND NEW.payload_json <> '{"suppressed": true}'::jsonb THEN
+      RAISE EXCEPTION 'secret payload must be suppressed';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_governance_audit_secret_payload_guard ON governance.audit_events;
+CREATE TRIGGER trg_governance_audit_secret_payload_guard
+BEFORE INSERT ON governance.audit_events
+FOR EACH ROW
+EXECUTE FUNCTION governance.enforce_secret_payload_suppression();
+
 CREATE TABLE IF NOT EXISTS governance.policy_decisions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   event_id TEXT NOT NULL,

--- a/python/governance_runtime/repos.py
+++ b/python/governance_runtime/repos.py
@@ -123,6 +123,24 @@ CREATE INDEX IF NOT EXISTS ix_governance_audit_events_run ON governance.audit_ev
 CREATE INDEX IF NOT EXISTS ix_governance_audit_events_type_ts ON governance.audit_events(event_type, observed_at);
 CREATE INDEX IF NOT EXISTS ix_governance_audit_events_event_id ON governance.audit_events(event_id);
 
+CREATE OR REPLACE FUNCTION governance.enforce_secret_payload_suppression()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.contains_secrets THEN
+    IF NEW.payload_json <> '{}'::jsonb AND NEW.payload_json <> '{"suppressed": true}'::jsonb THEN
+      RAISE EXCEPTION 'secret payload must be suppressed';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_governance_audit_secret_payload_guard ON governance.audit_events;
+CREATE TRIGGER trg_governance_audit_secret_payload_guard
+BEFORE INSERT ON governance.audit_events
+FOR EACH ROW
+EXECUTE FUNCTION governance.enforce_secret_payload_suppression();
+
 CREATE TABLE IF NOT EXISTS governance.policy_decisions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   event_id TEXT NOT NULL,

--- a/tests/test_governance_audit_events.py
+++ b/tests/test_governance_audit_events.py
@@ -1,4 +1,5 @@
 from python.governance_runtime.audit_events import build_audit_event, sanitize_payload
+from python.governance_runtime.event_taxonomy import EVENT_SECURITY_SECRET_SCAN_FAILED
 
 
 def test_sanitize_payload_redacts_secrets_and_detects_pii():
@@ -76,3 +77,22 @@ def test_build_audit_event_empty_type_falls_back_to_governance_event():
         prev_event_hash="sha256:0",
     )
     assert audit["event_type"] == "governance.event"
+
+
+def test_build_audit_event_scan_failure_fails_closed(monkeypatch):
+    def _raise(_payload):
+        raise RuntimeError("scan error")
+
+    monkeypatch.setattr("python.governance_runtime.audit_events.sanitize_payload", _raise)
+
+    audit = build_audit_event(
+        base_event={"type": "tool.call.requested", "tool_name": "slack:post_message"},
+        run_id="run-5",
+        sequence_number=1,
+        prev_event_hash="sha256:0",
+    )
+    assert audit["event_type"] == EVENT_SECURITY_SECRET_SCAN_FAILED
+    assert audit["contains_secrets"] is True
+    assert audit["payload_json"] == {"suppressed": True}
+    assert audit["redaction_ratio"] == 1.0
+    assert audit["scan_failed"] is True

--- a/tests/test_governance_repo_ddl.py
+++ b/tests/test_governance_repo_ddl.py
@@ -1,0 +1,6 @@
+from python.governance_runtime.repos import _GOVERNANCE_DDL
+
+
+def test_governance_audit_secret_payload_guard_present_in_ddl():
+    assert "enforce_secret_payload_suppression" in _GOVERNANCE_DDL
+    assert "trg_governance_audit_secret_payload_guard" in _GOVERNANCE_DDL


### PR DESCRIPTION
## Summary
- make audit event sanitization fail-closed when scanning raises
- emit `security.secret_scan_failed` and suppress payload on scan failure
- add DB-level trigger guard to enforce suppressed payload when `contains_secrets=true`
- add regression tests for fail-closed behavior and DDL guard presence

## Validation
- `./tools/e2e.sh`
  - `24 passed`
