### PR TITLE
feat(governance): emit run outcome on cancellation

### DIFF
--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 
 EVENT_RUN_STARTED = "run.started"
+EVENT_RUN_OUTCOME = "run.outcome"
 EVENT_TOOL_CALL_REQUESTED = "tool.call.requested"
 EVENT_POLICY_CHECK_DECISION = "policy.check.decision"
 EVENT_APPROVAL_REQUESTED = "approval.requested"

--- a/python/governance_runtime/temporal_client.py
+++ b/python/governance_runtime/temporal_client.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - optional in environments without Tempora
     Client = None  # type: ignore[assignment]
 
 from python.governance_runtime.repos import get_postgres_repo
+from python.governance_runtime.event_taxonomy import EVENT_RUN_OUTCOME
 
 
 _RUN_STATUS_BY_SIGNAL = {
@@ -99,6 +100,16 @@ def _db_fallback_signal(*, run_id: str, signal: str, payload: dict[str, Any] | N
                     "payload": payload or {},
                 }
             )
+            if sig == "cancel":
+                repo.append_event(
+                    {
+                        "type": EVENT_RUN_OUTCOME,
+                        "run_id": run_id,
+                        "outcome": "cancelled",
+                        "status": status,
+                        "source": "temporal_client_fallback",
+                    }
+                )
             persisted = True
         except Exception:
             persisted = False

--- a/python/governance_runtime/temporal_workflow.py
+++ b/python/governance_runtime/temporal_workflow.py
@@ -7,6 +7,7 @@ from typing import Any
 from temporalio import activity, workflow
 
 with workflow.unsafe.imports_passed_through():
+    from python.governance_runtime.event_taxonomy import EVENT_RUN_OUTCOME
     from python.governance_runtime.repos import get_postgres_repo
 
 
@@ -59,6 +60,22 @@ async def persist_run_signal(
         }
     )
 
+@activity.defn
+async def persist_run_outcome(run_id: str, status: str, outcome: str) -> None:
+    repo = get_postgres_repo()
+    if repo is None:
+        return
+
+    repo.append_event(
+        {
+            "type": EVENT_RUN_OUTCOME,
+            "run_id": run_id,
+            "status": status,
+            "outcome": outcome,
+            "source": "temporal_workflow",
+        }
+    )
+
 
 @workflow.defn
 class GovernedRunWorkflow:
@@ -94,6 +111,12 @@ class GovernedRunWorkflow:
                     args=[input_data.run_id, signal, self._status, payload],
                     start_to_close_timeout=timedelta(seconds=15),
                 )
+                if signal == "cancel":
+                    await workflow.execute_activity(
+                        persist_run_outcome,
+                        args=[input_data.run_id, self._status, "cancelled"],
+                        start_to_close_timeout=timedelta(seconds=15),
+                    )
 
         return {"run_id": input_data.run_id, "status": self._status}
 

--- a/tests/test_governance_temporal_signals.py
+++ b/tests/test_governance_temporal_signals.py
@@ -59,3 +59,22 @@ def test_signal_governed_run_updates_status_and_event(monkeypatch):
     assert out["persisted"] is True
     assert repo.updated == [("11111111-1111-1111-1111-111111111111", "paused")]
     assert repo.events and repo.events[0]["type"] == "run.signaled"
+
+
+def test_signal_governed_run_cancel_emits_outcome_event(monkeypatch):
+    repo = _FakeRepo()
+    monkeypatch.setattr(temporal_client, "get_postgres_repo", lambda: repo)
+
+    out = asyncio.run(
+        temporal_client.signal_governed_run(
+            run_id="11111111-1111-1111-1111-111111111111",
+            signal="cancel",
+            payload={"reason": "manual"},
+        )
+    )
+
+    assert out["status"] == "cancelled"
+    assert out["persisted"] is True
+    assert repo.updated == [("11111111-1111-1111-1111-111111111111", "cancelled")]
+    event_types = [e.get("type") for e in repo.events]
+    assert event_types == ["run.signaled", "run.outcome"]


### PR DESCRIPTION
## Summary
- add canonical `run.outcome` event constant to governance taxonomy
- emit `run.outcome` when a governed run is cancelled via Temporal workflow activity path
- emit matching `run.outcome` in DB fallback signal path for deterministic parity
- add regression test covering cancel signal outcome emission

## Validation
- `./tools/e2e.sh`
  - `25 passed`
