### PR TITLE
feat(governance): emit deterministic llm parse events

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -34,6 +34,10 @@ from typing import Callable
 from python.helpers.localization import Localization
 from python.helpers.extension import call_extensions
 from python.helpers.errors import RepairableException
+from python.governance_runtime.event_taxonomy import (
+    EVENT_LLM_RESPONSE_PARSED,
+    EVENT_LLM_RESPONSE_PARSE_FAILED,
+)
 
 
 class AgentContextType(Enum):
@@ -854,6 +858,8 @@ class Agent:
         tool_request = extract_tools.json_parse_dirty(msg)
 
         if tool_request is not None:
+            from python.helpers.governance_gate import emit_governance_runtime_event
+
             # valid structured output resets misformat streak
             previous_streak = int(self.get_data(Agent.DATA_NAME_MISFORMAT_STREAK) or 0)
             self.set_data(Agent.DATA_NAME_MISFORMAT_STREAK, 0)
@@ -869,6 +875,16 @@ class Agent:
             tool_args = tool_request.get("tool_args", tool_request.get("args", {}))
             if not isinstance(tool_args, dict):
                 tool_args = {}
+            emit_governance_runtime_event(
+                self,
+                {
+                    "type": EVENT_LLM_RESPONSE_PARSED,
+                    "tool_name": str(raw_tool_name or ""),
+                    "parsed": True,
+                    "arg_keys": sorted(str(k) for k in tool_args.keys()),
+                    "source": "agent.process_tools",
+                },
+            )
 
             tool_name = raw_tool_name  # Initialize tool_name with raw_tool_name
             tool_method = None  # Initialize tool_method
@@ -996,8 +1012,20 @@ class Agent:
                     type="warning", content=f"{self.agent_name}: {error_detail}"
                 )
         else:
+            from python.helpers.governance_gate import emit_governance_runtime_event
+
             misformat_streak = int(self.get_data(Agent.DATA_NAME_MISFORMAT_STREAK) or 0) + 1
             self.set_data(Agent.DATA_NAME_MISFORMAT_STREAK, misformat_streak)
+            emit_governance_runtime_event(
+                self,
+                {
+                    "type": EVENT_LLM_RESPONSE_PARSE_FAILED,
+                    "parsed": False,
+                    "reason": "no_valid_tool_request",
+                    "misformat_streak": misformat_streak,
+                    "source": "agent.process_tools",
+                },
+            )
             warning_msg_misformat = self.read_prompt("fw.msg_misformat.md")
             self.hist_add_warning(warning_msg_misformat)
             PrintStyle(font_color="red", padding=True).print(warning_msg_misformat)

--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 EVENT_RUN_STARTED = "run.started"
 EVENT_RUN_OUTCOME = "run.outcome"
+EVENT_LLM_RESPONSE_PARSED = "llm.response.parsed"
+EVENT_LLM_RESPONSE_PARSE_FAILED = "llm.response.parse_failed"
 EVENT_TOOL_CALL_REQUESTED = "tool.call.requested"
 EVENT_POLICY_CHECK_DECISION = "policy.check.decision"
 EVENT_APPROVAL_REQUESTED = "approval.requested"

--- a/python/helpers/governance_gate.py
+++ b/python/helpers/governance_gate.py
@@ -143,6 +143,20 @@ def _emit_run_started_once(agent: Any, project_name: str) -> None:
     )
 
 
+def emit_governance_runtime_event(agent: Any, event: dict[str, Any]) -> None:
+    """Emit deterministic runtime event only when governance is enabled for active project."""
+    gov = _load_project_governance(agent)
+    if not bool(gov.get("governance_enabled", False)):
+        return
+    project_name = str(gov.get("project_name") or "").strip()
+    if not project_name:
+        return
+    _emit_run_started_once(agent, project_name)
+    enriched = dict(event or {})
+    enriched.setdefault("project_name", project_name)
+    _emit_governance_event(agent, enriched)
+
+
 def _load_project_governance(agent: Any) -> dict[str, Any]:
     from python.helpers import projects
 

--- a/tests/test_agent_misformat_guard.py
+++ b/tests/test_agent_misformat_guard.py
@@ -2,6 +2,7 @@ import asyncio
 
 from agent import Agent
 from python.helpers import extract_tools
+from python.helpers import governance_gate
 
 
 class _DummyLog:
@@ -31,6 +32,8 @@ def _build_agent_for_process_tools() -> Agent:
 
 def test_process_tools_breaks_after_repeated_misformat(monkeypatch):
     monkeypatch.setattr(extract_tools, "json_parse_dirty", lambda _msg: None)
+    emitted: list[dict] = []
+    monkeypatch.setattr(governance_gate, "emit_governance_runtime_event", lambda _agent, event: emitted.append(event))
     agent = _build_agent_for_process_tools()
 
     # First two malformed responses should continue.
@@ -44,11 +47,16 @@ def test_process_tools_breaks_after_repeated_misformat(monkeypatch):
 
     # Streak resets after break to avoid sticky state.
     assert agent.get_data(Agent.DATA_NAME_MISFORMAT_STREAK) == 0
+    parse_failed = [e for e in emitted if e.get("type") == "llm.response.parse_failed"]
+    assert len(parse_failed) == 3
+    assert parse_failed[-1]["misformat_streak"] == 3
 
 
 def test_process_tools_resets_misformat_streak_on_valid_tool_request(monkeypatch):
     agent = _build_agent_for_process_tools()
     agent.set_data(Agent.DATA_NAME_MISFORMAT_STREAK, 2)
+    emitted: list[dict] = []
+    monkeypatch.setattr(governance_gate, "emit_governance_runtime_event", lambda _agent, event: emitted.append(event))
 
     # Return a parseable request with unknown tool so method takes structured path.
     monkeypatch.setattr(
@@ -65,3 +73,4 @@ def test_process_tools_resets_misformat_streak_on_valid_tool_request(monkeypatch
         "misformat streak reset after 2 malformed output(s)" in content
         for _type, content in agent.context.log.entries
     )
+    assert any(e.get("type") == "llm.response.parsed" for e in emitted)

--- a/tests/test_governance_input.py
+++ b/tests/test_governance_input.py
@@ -264,3 +264,34 @@ def test_run_started_is_emitted_once_per_context(monkeypatch):
 
     run_started_events = [e for e in events if e.get("type") == "run.started"]
     assert len(run_started_events) == 1
+
+
+def test_emit_governance_runtime_event_only_when_enabled(monkeypatch):
+    from python.helpers import governance_gate
+
+    events: list[dict] = []
+    agent = _DummyAgent()
+
+    monkeypatch.setattr(
+        governance_gate,
+        "_load_project_governance",
+        lambda _agent: {"project_name": "p1", "governance_enabled": True},
+    )
+    monkeypatch.setattr(governance_gate, "_append_governance_event", lambda event: events.append(event))
+
+    governance_gate.emit_governance_runtime_event(
+        agent,
+        {"type": "llm.response.parsed", "tool_name": "search_engine"},
+    )
+
+    assert any(e.get("type") == "run.started" for e in events)
+    assert any(e.get("type") == "llm.response.parsed" for e in events)
+
+    events.clear()
+    monkeypatch.setattr(
+        governance_gate,
+        "_load_project_governance",
+        lambda _agent: {"project_name": "p1", "governance_enabled": False},
+    )
+    governance_gate.emit_governance_runtime_event(agent, {"type": "llm.response.parse_failed"})
+    assert events == []


### PR DESCRIPTION
## Summary
- add canonical LLM parse event types: `llm.response.parsed` and `llm.response.parse_failed`
- emit deterministic parse events from `Agent.process_tools` on both valid parse and misformat branches
- add reusable `emit_governance_runtime_event()` helper to gate runtime event emission to governance-enabled projects
- add regression coverage for parse-failed streak events and parse-success event emission

## Validation
- `./tools/e2e.sh`
  - `26 passed`
