### PR TITLE
feat(governance): emit llm request and response events

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -35,6 +35,8 @@ from python.helpers.localization import Localization
 from python.helpers.extension import call_extensions
 from python.helpers.errors import RepairableException
 from python.governance_runtime.event_taxonomy import (
+    EVENT_LLM_REQUEST_SENT,
+    EVENT_LLM_RESPONSE_RECEIVED,
     EVENT_LLM_RESPONSE_PARSED,
     EVENT_LLM_RESPONSE_PARSE_FAILED,
 )
@@ -770,6 +772,7 @@ class Agent:
         background: bool = False,
     ):
         model = self.get_utility_model()
+        from python.helpers.governance_gate import emit_governance_runtime_event
 
         # call extensions
         call_data = {
@@ -780,6 +783,15 @@ class Agent:
             "background": background,
         }
         await self.call_extensions("util_model_call_before", call_data=call_data)
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_LLM_REQUEST_SENT,
+                "model_role": "utility",
+                "message_length": len(str(call_data.get("message", "") or "")),
+                "source": "agent.call_utility_model",
+            },
+        )
 
         # propagate stream to callback if set
         async def stream_callback(chunk: str, total: str):
@@ -794,6 +806,15 @@ class Agent:
                 self.rate_limiter_callback if not call_data["background"] else None
             ),
         )
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_LLM_RESPONSE_RECEIVED,
+                "model_role": "utility",
+                "response_length": len(str(response or "")),
+                "source": "agent.call_utility_model",
+            },
+        )
 
         return response
 
@@ -805,9 +826,19 @@ class Agent:
         background: bool = False,
     ):
         response = ""
+        from python.helpers.governance_gate import emit_governance_runtime_event
 
         # model class
         model = self.get_chat_model()
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_LLM_REQUEST_SENT,
+                "model_role": "chat",
+                "messages_count": len(messages),
+                "source": "agent.call_chat_model",
+            },
+        )
 
         # call model
         response, reasoning = await model.unified_call(
@@ -817,6 +848,15 @@ class Agent:
             rate_limiter_callback=(
                 self.rate_limiter_callback if not background else None
             ),
+        )
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_LLM_RESPONSE_RECEIVED,
+                "model_role": "chat",
+                "response_length": len(str(response or "")),
+                "source": "agent.call_chat_model",
+            },
         )
 
         return response, reasoning

--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 EVENT_RUN_STARTED = "run.started"
 EVENT_RUN_OUTCOME = "run.outcome"
+EVENT_LLM_REQUEST_SENT = "llm.request.sent"
+EVENT_LLM_RESPONSE_RECEIVED = "llm.response.received"
 EVENT_LLM_RESPONSE_PARSED = "llm.response.parsed"
 EVENT_LLM_RESPONSE_PARSE_FAILED = "llm.response.parse_failed"
 EVENT_TOOL_CALL_REQUESTED = "tool.call.requested"

--- a/tests/test_governance_llm_events.py
+++ b/tests/test_governance_llm_events.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+
+from agent import Agent
+
+
+class _DummyModel:
+    async def unified_call(self, **_kwargs):
+        return ("ok-response", "")
+
+
+def _build_agent_for_llm_calls() -> Agent:
+    agent = Agent.__new__(Agent)
+    agent.call_extensions = lambda *_args, **_kwargs: asyncio.sleep(0)
+    agent.get_chat_model = lambda: _DummyModel()
+    agent.get_utility_model = lambda: _DummyModel()
+    return agent
+
+
+def test_call_chat_model_emits_llm_request_and_response_events(monkeypatch):
+    from python.helpers import governance_gate
+
+    emitted: list[dict] = []
+    monkeypatch.setattr(governance_gate, "emit_governance_runtime_event", lambda _agent, event: emitted.append(event))
+
+    agent = _build_agent_for_llm_calls()
+    out, _reasoning = asyncio.run(agent.call_chat_model(messages=[], background=True))
+
+    assert out == "ok-response"
+    event_types = [e.get("type") for e in emitted]
+    assert event_types == ["llm.request.sent", "llm.response.received"]
+    assert emitted[0]["model_role"] == "chat"
+    assert emitted[1]["model_role"] == "chat"
+
+
+def test_call_utility_model_emits_llm_request_and_response_events(monkeypatch):
+    from python.helpers import governance_gate
+
+    emitted: list[dict] = []
+    monkeypatch.setattr(governance_gate, "emit_governance_runtime_event", lambda _agent, event: emitted.append(event))
+
+    agent = _build_agent_for_llm_calls()
+    out = asyncio.run(agent.call_utility_model(system="sys", message="hello", background=True))
+
+    assert out == "ok-response"
+    event_types = [e.get("type") for e in emitted]
+    assert event_types == ["llm.request.sent", "llm.response.received"]
+    assert emitted[0]["model_role"] == "utility"
+    assert emitted[1]["model_role"] == "utility"


### PR DESCRIPTION
## Summary
- add canonical LLM lifecycle events: `llm.request.sent` and `llm.response.received`
- emit deterministic governance runtime events around both chat and utility model calls
- include basic metadata in events (`model_role`, size/count fields, source)
- add regression tests for event emission sequence in model call paths

## Validation
- `./tools/e2e.sh`
  - `26 passed`
