### PR TITLE
Emit run.outcome when misformat retries are exhausted

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -39,6 +39,7 @@ from python.governance_runtime.event_taxonomy import (
     EVENT_LLM_RESPONSE_RECEIVED,
     EVENT_LLM_RESPONSE_PARSED,
     EVENT_LLM_RESPONSE_PARSE_FAILED,
+    EVENT_RUN_OUTCOME,
 )
 
 
@@ -1087,6 +1088,17 @@ class Agent:
                 self.context.log.log(
                     type="warning",
                     content=f"{self.agent_name}: {loop_break_msg}",
+                )
+                emit_governance_runtime_event(
+                    self,
+                    {
+                        "type": EVENT_RUN_OUTCOME,
+                        "outcome": "failure",
+                        "status": "error",
+                        "reason": "parse_failed_exhausted",
+                        "misformat_streak": misformat_streak,
+                        "source": "agent.process_tools",
+                    },
                 )
                 self.set_data(Agent.DATA_NAME_MISFORMAT_STREAK, 0)
                 return loop_break_msg

--- a/tests/test_agent_misformat_guard.py
+++ b/tests/test_agent_misformat_guard.py
@@ -50,6 +50,10 @@ def test_process_tools_breaks_after_repeated_misformat(monkeypatch):
     parse_failed = [e for e in emitted if e.get("type") == "llm.response.parse_failed"]
     assert len(parse_failed) == 3
     assert parse_failed[-1]["misformat_streak"] == 3
+    run_outcomes = [e for e in emitted if e.get("type") == "run.outcome"]
+    assert len(run_outcomes) == 1
+    assert run_outcomes[0]["outcome"] == "failure"
+    assert run_outcomes[0]["reason"] == "parse_failed_exhausted"
 
 
 def test_process_tools_resets_misformat_streak_on_valid_tool_request(monkeypatch):


### PR DESCRIPTION
## Summary
- emit a run.outcome governance event when Agent.process_tools breaks after repeated malformed tool outputs
- include deterministic failure reason parse_failed_exhausted and misformat_streak
- extend misformat guard regression test to assert this event

## Validation
- ./tools/e2e.sh (Docker CI-equivalent): 26 passed