### PR TITLE
Emit prompt.final.rendered events for governed LLM calls

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,4 +1,4 @@
-import asyncio, random, string, threading
+import asyncio, hashlib, random, string, threading
 import nest_asyncio
 
 nest_asyncio.apply()
@@ -39,6 +39,7 @@ from python.governance_runtime.event_taxonomy import (
     EVENT_LLM_RESPONSE_RECEIVED,
     EVENT_LLM_RESPONSE_PARSED,
     EVENT_LLM_RESPONSE_PARSE_FAILED,
+    EVENT_PROMPT_FINAL_RENDERED,
     EVENT_RUN_OUTCOME,
 )
 
@@ -784,6 +785,18 @@ class Agent:
             "background": background,
         }
         await self.call_extensions("util_model_call_before", call_data=call_data)
+        rendered_prompt_hash = hashlib.sha256(
+            f"{call_data.get('system', '')}\n\n{call_data.get('message', '')}".encode("utf-8")
+        ).hexdigest()
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_PROMPT_FINAL_RENDERED,
+                "model_role": "utility",
+                "prompt_hash": rendered_prompt_hash,
+                "source": "agent.call_utility_model",
+            },
+        )
         emit_governance_runtime_event(
             self,
             {
@@ -831,6 +844,18 @@ class Agent:
 
         # model class
         model = self.get_chat_model()
+        rendered_prompt = "\n\n".join(str(getattr(m, "content", "") or "") for m in messages)
+        rendered_prompt_hash = hashlib.sha256(rendered_prompt.encode("utf-8")).hexdigest()
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_PROMPT_FINAL_RENDERED,
+                "model_role": "chat",
+                "prompt_hash": rendered_prompt_hash,
+                "messages_count": len(messages),
+                "source": "agent.call_chat_model",
+            },
+        )
         emit_governance_runtime_event(
             self,
             {

--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 EVENT_RUN_STARTED = "run.started"
 EVENT_RUN_OUTCOME = "run.outcome"
+EVENT_PROMPT_FINAL_RENDERED = "prompt.final.rendered"
 EVENT_LLM_REQUEST_SENT = "llm.request.sent"
 EVENT_LLM_RESPONSE_RECEIVED = "llm.response.received"
 EVENT_LLM_RESPONSE_PARSED = "llm.response.parsed"

--- a/tests/test_governance_llm_events.py
+++ b/tests/test_governance_llm_events.py
@@ -29,9 +29,11 @@ def test_call_chat_model_emits_llm_request_and_response_events(monkeypatch):
 
     assert out == "ok-response"
     event_types = [e.get("type") for e in emitted]
-    assert event_types == ["llm.request.sent", "llm.response.received"]
+    assert event_types == ["prompt.final.rendered", "llm.request.sent", "llm.response.received"]
     assert emitted[0]["model_role"] == "chat"
+    assert emitted[0]["prompt_hash"]
     assert emitted[1]["model_role"] == "chat"
+    assert emitted[2]["model_role"] == "chat"
 
 
 def test_call_utility_model_emits_llm_request_and_response_events(monkeypatch):
@@ -45,6 +47,8 @@ def test_call_utility_model_emits_llm_request_and_response_events(monkeypatch):
 
     assert out == "ok-response"
     event_types = [e.get("type") for e in emitted]
-    assert event_types == ["llm.request.sent", "llm.response.received"]
+    assert event_types == ["prompt.final.rendered", "llm.request.sent", "llm.response.received"]
     assert emitted[0]["model_role"] == "utility"
+    assert emitted[0]["prompt_hash"]
     assert emitted[1]["model_role"] == "utility"
+    assert emitted[2]["model_role"] == "utility"


### PR DESCRIPTION
## Summary
- add `prompt.final.rendered` to governance event taxonomy
- emit deterministic prompt hash events before chat/utility model invocations
- extend governance llm event tests to assert prompt render events and ordering

## Validation
- ./tools/e2e.sh (Docker CI-equivalent): 26 passed