### PR TITLE
Emit user.message.created event in governed runtime

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -41,6 +41,7 @@ from python.governance_runtime.event_taxonomy import (
     EVENT_LLM_RESPONSE_PARSE_FAILED,
     EVENT_PROMPT_FINAL_RENDERED,
     EVENT_RUN_OUTCOME,
+    EVENT_USER_MESSAGE_CREATED,
 )
 
 
@@ -685,6 +686,19 @@ class Agent:
 
     def hist_add_user_message(self, message: UserMessage, intervention: bool = False):
         self.history.new_topic()  # user message starts a new topic in history
+        from python.helpers.governance_gate import emit_governance_runtime_event
+
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_USER_MESSAGE_CREATED,
+                "message_length": len(str(message.message or "")),
+                "attachments_count": len(message.attachments or []),
+                "system_message_count": len(message.system_message or []),
+                "intervention": bool(intervention),
+                "source": "agent.hist_add_user_message",
+            },
+        )
 
         # load message template based on intervention
         if intervention:

--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 EVENT_RUN_STARTED = "run.started"
 EVENT_RUN_OUTCOME = "run.outcome"
+EVENT_USER_MESSAGE_CREATED = "user.message.created"
 EVENT_PROMPT_FINAL_RENDERED = "prompt.final.rendered"
 EVENT_LLM_REQUEST_SENT = "llm.request.sent"
 EVENT_LLM_RESPONSE_RECEIVED = "llm.response.received"

--- a/tests/test_governance_user_message_events.py
+++ b/tests/test_governance_user_message_events.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from agent import Agent, UserMessage
+
+
+def _build_agent_for_user_message() -> Agent:
+    agent = Agent.__new__(Agent)
+    agent.history = type("_History", (), {"new_topic": lambda self: None})()
+    agent.parse_prompt = lambda *_args, **_kwargs: {"message": "ok"}
+    agent.hist_add_message = lambda _ai, _content, tokens=0: {"id": "m1", "tokens": tokens}
+    agent.last_user_message = None
+    return agent
+
+
+def test_hist_add_user_message_emits_user_message_created(monkeypatch):
+    from python.helpers import governance_gate
+
+    emitted: list[dict] = []
+    monkeypatch.setattr(
+        governance_gate,
+        "emit_governance_runtime_event",
+        lambda _agent, event: emitted.append(event),
+    )
+
+    agent = _build_agent_for_user_message()
+    msg = UserMessage(
+        message="hello governed world",
+        attachments=["file://a.txt", "file://b.txt"],
+        system_message=["sys-1"],
+    )
+    agent.hist_add_user_message(msg, intervention=False)
+
+    assert emitted
+    event = emitted[0]
+    assert event["type"] == "user.message.created"
+    assert event["message_length"] == len("hello governed world")
+    assert event["attachments_count"] == 2
+    assert event["system_message_count"] == 1
+    assert event["intervention"] is False
+


### PR DESCRIPTION
## Summary
- add `user.message.created` to governance event taxonomy
- emit deterministic user message ingress event from `hist_add_user_message`
- include message/attachment/system-message counts and intervention flag
- add focused regression test for event emission

## Validation
- ./tools/e2e.sh (Docker CI-equivalent): 26 passed