### PR TITLE
Emit prompt.template.selected in governed runtime

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -39,6 +39,7 @@ from python.governance_runtime.event_taxonomy import (
     EVENT_LLM_RESPONSE_RECEIVED,
     EVENT_LLM_RESPONSE_PARSED,
     EVENT_LLM_RESPONSE_PARSE_FAILED,
+    EVENT_PROMPT_TEMPLATE_SELECTED,
     EVENT_PROMPT_FINAL_RENDERED,
     EVENT_RUN_OUTCOME,
     EVENT_USER_MESSAGE_CREATED,
@@ -659,6 +660,17 @@ class Agent:
         return prompt
 
     def read_prompt(self, file: str, **kwargs) -> str:
+        from python.helpers.governance_gate import emit_governance_runtime_event
+
+        emit_governance_runtime_event(
+            self,
+            {
+                "type": EVENT_PROMPT_TEMPLATE_SELECTED,
+                "template": str(file),
+                "kwargs_keys": sorted(str(k) for k in kwargs.keys()),
+                "source": "agent.read_prompt",
+            },
+        )
         dirs = subagents.get_paths(self, "prompts")
         prompt = files.read_prompt_file(file, _directories=dirs, _agent=self, **kwargs)
         if files.is_full_json_template(prompt):

--- a/python/governance_runtime/event_taxonomy.py
+++ b/python/governance_runtime/event_taxonomy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 EVENT_RUN_STARTED = "run.started"
 EVENT_RUN_OUTCOME = "run.outcome"
 EVENT_USER_MESSAGE_CREATED = "user.message.created"
+EVENT_PROMPT_TEMPLATE_SELECTED = "prompt.template.selected"
 EVENT_PROMPT_FINAL_RENDERED = "prompt.final.rendered"
 EVENT_LLM_REQUEST_SENT = "llm.request.sent"
 EVENT_LLM_RESPONSE_RECEIVED = "llm.response.received"

--- a/tests/test_governance_prompt_template_events.py
+++ b/tests/test_governance_prompt_template_events.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from agent import Agent
+
+
+def _build_agent_for_read_prompt() -> Agent:
+    agent = Agent.__new__(Agent)
+    return agent
+
+
+def test_read_prompt_emits_prompt_template_selected(monkeypatch):
+    from python.helpers import governance_gate
+    from python.helpers import files
+    from python.helpers import subagents
+
+    emitted: list[dict] = []
+    monkeypatch.setattr(
+        governance_gate,
+        "emit_governance_runtime_event",
+        lambda _agent, event: emitted.append(event),
+    )
+    monkeypatch.setattr(subagents, "get_paths", lambda *_args, **_kwargs: ["/tmp/prompts"])
+    monkeypatch.setattr(
+        files,
+        "read_prompt_file",
+        lambda _file, _directories=None, _agent=None, **_kwargs: "prompt-body",
+    )
+    monkeypatch.setattr(files, "is_full_json_template", lambda _prompt: False)
+
+    agent = _build_agent_for_read_prompt()
+    out = agent.read_prompt("fw.msg_misformat.md", a=1, b="x")
+
+    assert out == "prompt-body"
+    assert emitted
+    event = emitted[0]
+    assert event["type"] == "prompt.template.selected"
+    assert event["template"] == "fw.msg_misformat.md"
+    assert event["kwargs_keys"] == ["a", "b"]
+


### PR DESCRIPTION
## Summary
- add `prompt.template.selected` to governance event taxonomy
- emit deterministic template selection event in `Agent.read_prompt`
- include selected template and sorted kwargs keys
- add regression test for prompt template event emission

## Validation
- ./tools/e2e.sh (Docker CI-equivalent): 26 passed