### PR TITLE
Expand governance tracing phase-1 batch (events + e2e audit smoke)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,7 +58,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py tests/test_governance_dataset_export.py tests/test_governance_dataset_retention.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py tests/test_governance_dataset_export.py tests/test_governance_dataset_retention.py tests/test_governance_training_trigger.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
       ]
     depends_on:
       postgres:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -56,7 +56,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py"
       ]
 
 volumes:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,7 +58,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
       ]
     depends_on:
       postgres:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,7 +58,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py tests/test_governance_dataset_export.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
       ]
     depends_on:
       postgres:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,7 +58,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
       ]
     depends_on:
       postgres:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -52,12 +52,17 @@ services:
       dockerfile: Dockerfile.e2e
     environment:
       PYTHONPATH: /a0
+      DATABASE_URL: postgresql+psycopg://agentzero:agentzero@postgres:5432/agentzero
+      GOV_PERSIST_BACKEND: postgres
     command:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py"
       ]
+    depends_on:
+      postgres:
+        condition: service_healthy
 
 volumes:
   postgres-data:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,7 +58,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py tests/test_governance_dataset_export.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py tests/test_governance_dataset_quality.py tests/test_governance_dataset_export.py tests/test_governance_dataset_retention.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
       ]
     depends_on:
       postgres:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -58,7 +58,7 @@ services:
       [
         "bash",
         "-lc",
-        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
+        "PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/pytest -q tests/test_governance_api_phase2.py tests/test_governance_temporal_signals.py tests/test_governance_persistence_db.py tests/test_governance_input.py tests/test_governance_llm_events.py tests/test_agent_misformat_guard.py tests/test_governance_user_message_events.py tests/test_governance_prompt_template_events.py tests/test_governance_dataset_builder.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_smoke.py && PYTHONPATH=/a0 /opt/pyenv/versions/3.12.4/bin/python tools/governance_audit_query_pack.py"
       ]
     depends_on:
       postgres:

--- a/python/api/training_candidates.py
+++ b/python/api/training_candidates.py
@@ -11,6 +11,9 @@ from python.helpers.governance_gate import load_governance_events
 from python.helpers.training_candidates_store import apply_candidate_overrides
 
 
+ALLOWED_CONSENT_SCOPES = {"audit_only", "eval_allowed", "training_allowed"}
+
+
 def _parse_iso_dt(value: str | None) -> dt.datetime | None:
     if not value:
         return None
@@ -70,6 +73,9 @@ def _candidate_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "status": event.get("status"),
         "signal": event.get("signal"),
     }
+    consent_scope = str(event.get("consent_scope", "")).strip().lower()
+    if consent_scope not in ALLOWED_CONSENT_SCOPES:
+        consent_scope = "eval_allowed"
 
     base = {
         "project_name": event.get("project_name"),
@@ -82,6 +88,7 @@ def _candidate_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "summary": summary,
         "source_event": event,
         "payload": candidate_payload,
+        "consent_scope": consent_scope,
     }
 
     unique_material = json.dumps(
@@ -106,6 +113,7 @@ def _matches_filters(
     event_type: str,
     training_status: str,
     run_id: str,
+    consent_scope: str,
     from_ts: dt.datetime | None,
     to_ts: dt.datetime | None,
 ) -> bool:
@@ -114,6 +122,8 @@ def _matches_filters(
     if training_status and str(candidate.get("training_status", "")).strip().lower() != training_status:
         return False
     if run_id and str(candidate.get("run_id", "")).strip() != run_id:
+        return False
+    if consent_scope and str(candidate.get("consent_scope", "")).strip().lower() != consent_scope:
         return False
 
     ts = _parse_iso_dt(candidate.get("created_at"))
@@ -173,6 +183,10 @@ class TrainingCandidates(ApiHandler):
         event_type = str(input.get("event_type", "")).strip().lower()
         training_status = str(input.get("training_status", input.get("status", ""))).strip().lower()
         run_id = str(input.get("run_id", "")).strip()
+        consent_scope = str(input.get("consent_scope", "")).strip().lower()
+        if consent_scope and consent_scope not in ALLOWED_CONSENT_SCOPES:
+            consent_scope = ""
+        export_purpose = str(input.get("export_purpose", "eval")).strip().lower() or "eval"
         export_format = str(input.get("export_format", "")).strip().lower()
         from_ts = _parse_iso_dt(input.get("from_ts"))
         to_ts = _parse_iso_dt(input.get("to_ts"))
@@ -196,17 +210,24 @@ class TrainingCandidates(ApiHandler):
                 event_type=event_type,
                 training_status=training_status,
                 run_id=run_id,
+                consent_scope=consent_scope,
                 from_ts=from_ts,
                 to_ts=to_ts,
             ):
                 continue
             candidates.append(cand)
 
+        if export_purpose == "training":
+            allowed_export_scopes = {"training_allowed"}
+        else:
+            allowed_export_scopes = {"eval_allowed", "training_allowed"}
+
         total = len(candidates)
         page = candidates[offset : offset + limit]
         page = apply_candidate_overrides(project_name, page)
 
         if export_format in {"jsonl", "csv"}:
+            page = [item for item in page if str(item.get("consent_scope", "")).strip().lower() in allowed_export_scopes]
             if export_format == "jsonl":
                 body = "".join(json.dumps(item, sort_keys=True, default=str) + "\n" for item in page)
                 return Response(

--- a/python/helpers/governance_dataset_builder.py
+++ b/python/helpers/governance_dataset_builder.py
@@ -158,13 +158,25 @@ def build_dataset_manifest(
         }
     )
     source_event_digest = hashlib.sha256(json.dumps(source_event_ids, sort_keys=True).encode("utf-8")).hexdigest()
+    train_eligible_count = 0
+    gold_count = 0
+    for record in records:
+        labels = record.get("labels") if isinstance(record.get("labels"), dict) else {}
+        quality = record.get("quality") if isinstance(record.get("quality"), dict) else {}
+        if bool(labels.get("train_eligible", quality.get("train_eligible", False))):
+            train_eligible_count += 1
+        if bool(labels.get("gold", quality.get("gold", False))):
+            gold_count += 1
     return {
         "dataset_version": DATASET_VERSION,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "purpose": purpose,
         "project_name": project_name,
         "record_count": len(records),
         "run_count": len(run_ids),
         "run_ids": run_ids,
+        "train_eligible_count": train_eligible_count,
+        "gold_count": gold_count,
         "source_event_count": len(source_event_ids),
         "source_event_ids_sha256": source_event_digest,
         "sha256": digest,

--- a/python/helpers/governance_dataset_builder.py
+++ b/python/helpers/governance_dataset_builder.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from collections import defaultdict
+from typing import Any
+
+
+DATASET_VERSION = "governance.flywheel.v1"
+CONSENT_ORDER = {"audit_only": 0, "eval_allowed": 1, "training_allowed": 2}
+
+
+def _parse_iso(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        return dt.datetime.fromisoformat(raw)
+    except Exception:
+        return None
+
+
+def _event_ts(event: dict[str, Any]) -> dt.datetime:
+    for key in ("event_ts", "created_at", "updated_at"):
+        parsed = _parse_iso(event.get(key))
+        if parsed is not None:
+            return parsed
+    return dt.datetime.fromtimestamp(0, tz=dt.timezone.utc)
+
+
+def _normalize_consent(value: Any) -> str:
+    consent = str(value or "").strip().lower()
+    if consent in CONSENT_ORDER:
+        return consent
+    return "eval_allowed"
+
+
+def _episode_id(run_id: str, events: list[dict[str, Any]]) -> str:
+    material = json.dumps(
+        {
+            "run_id": run_id,
+            "count": len(events),
+            "types": [str(e.get("type", "")) for e in events],
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return "ep_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def _consent_for_events(events: list[dict[str, Any]]) -> str:
+    best = "audit_only"
+    for event in events:
+        consent = _normalize_consent(event.get("consent_scope"))
+        if CONSENT_ORDER[consent] > CONSENT_ORDER[best]:
+            best = consent
+    return best
+
+
+def _is_allowed(consent: str, purpose: str) -> bool:
+    if purpose == "training":
+        return consent == "training_allowed"
+    return consent in {"eval_allowed", "training_allowed"}
+
+
+def build_episode_records(
+    events: list[dict[str, Any]],
+    *,
+    purpose: str = "eval",
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        run_id = str(event.get("run_id") or "").strip()
+        if not run_id:
+            continue
+        grouped[run_id].append(dict(event))
+
+    records: list[dict[str, Any]] = []
+    for run_id, run_events in grouped.items():
+        run_events.sort(key=_event_ts)
+        consent_scope = _consent_for_events(run_events)
+        if not _is_allowed(consent_scope, purpose):
+            continue
+
+        project_name = str(run_events[-1].get("project_name", "")).strip() or None
+        outcome = next(
+            (
+                str(event.get("outcome", "")).strip().lower()
+                for event in reversed(run_events)
+                if str(event.get("type", "")).strip().lower() == "run.outcome"
+            ),
+            "",
+        )
+
+        records.append(
+            {
+                "dataset_version": DATASET_VERSION,
+                "episode_id": _episode_id(run_id, run_events),
+                "run_id": run_id,
+                "project_name": project_name,
+                "consent_scope": consent_scope,
+                "purpose": purpose,
+                "labels": {
+                    "outcome": outcome or "unknown",
+                    "event_count": len(run_events),
+                },
+                "events": run_events,
+            }
+        )
+
+    records.sort(key=lambda item: (str(item.get("project_name") or ""), str(item.get("run_id") or "")))
+    return records
+
+
+def episode_records_to_jsonl(records: list[dict[str, Any]]) -> str:
+    return "".join(json.dumps(record, sort_keys=True, default=str) + "\n" for record in records)
+

--- a/python/helpers/governance_dataset_builder.py
+++ b/python/helpers/governance_dataset_builder.py
@@ -128,3 +128,23 @@ def build_episode_records(
 
 def episode_records_to_jsonl(records: list[dict[str, Any]]) -> str:
     return "".join(json.dumps(record, sort_keys=True, default=str) + "\n" for record in records)
+
+
+def build_dataset_manifest(
+    records: list[dict[str, Any]],
+    *,
+    purpose: str,
+    project_name: str | None,
+) -> dict[str, Any]:
+    jsonl_payload = episode_records_to_jsonl(records)
+    digest = hashlib.sha256(jsonl_payload.encode("utf-8")).hexdigest()
+    run_ids = sorted({str(record.get("run_id", "")) for record in records if str(record.get("run_id", "")).strip()})
+    return {
+        "dataset_version": DATASET_VERSION,
+        "purpose": purpose,
+        "project_name": project_name,
+        "record_count": len(records),
+        "run_count": len(run_ids),
+        "run_ids": run_ids,
+        "sha256": digest,
+    }

--- a/python/helpers/governance_dataset_builder.py
+++ b/python/helpers/governance_dataset_builder.py
@@ -6,6 +6,7 @@ import json
 from collections import defaultdict
 from typing import Any
 
+from python.helpers.governance_dataset_quality import score_episode
 
 DATASET_VERSION = "governance.flywheel.v1"
 CONSENT_ORDER = {"audit_only": 0, "eval_allowed": 1, "training_allowed": 2}
@@ -98,6 +99,7 @@ def build_episode_records(
             ),
             "",
         )
+        quality = score_episode(run_events)
 
         records.append(
             {
@@ -110,7 +112,12 @@ def build_episode_records(
                 "labels": {
                     "outcome": outcome or "unknown",
                     "event_count": len(run_events),
+                    "quality_score": quality["quality_score"],
+                    "train_eligible": quality["train_eligible"],
+                    "gold": quality["gold"],
+                    "tier": quality["tier"],
                 },
+                "quality": quality,
                 "events": run_events,
             }
         )
@@ -121,4 +128,3 @@ def build_episode_records(
 
 def episode_records_to_jsonl(records: list[dict[str, Any]]) -> str:
     return "".join(json.dumps(record, sort_keys=True, default=str) + "\n" for record in records)
-

--- a/python/helpers/governance_dataset_builder.py
+++ b/python/helpers/governance_dataset_builder.py
@@ -54,6 +54,14 @@ def _episode_id(run_id: str, events: list[dict[str, Any]]) -> str:
     return "ep_" + hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
 
 
+def _event_identity(event: dict[str, Any]) -> str:
+    event_id = str(event.get("event_id", "")).strip()
+    if event_id:
+        return event_id
+    payload = json.dumps(event, sort_keys=True, default=str)
+    return "ev_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
 def _consent_for_events(events: list[dict[str, Any]]) -> str:
     best = "audit_only"
     for event in events:
@@ -100,6 +108,7 @@ def build_episode_records(
             "",
         )
         quality = score_episode(run_events)
+        source_event_ids = [_event_identity(event) for event in run_events]
 
         records.append(
             {
@@ -118,6 +127,7 @@ def build_episode_records(
                     "tier": quality["tier"],
                 },
                 "quality": quality,
+                "source_event_ids": source_event_ids,
                 "events": run_events,
             }
         )
@@ -139,6 +149,15 @@ def build_dataset_manifest(
     jsonl_payload = episode_records_to_jsonl(records)
     digest = hashlib.sha256(jsonl_payload.encode("utf-8")).hexdigest()
     run_ids = sorted({str(record.get("run_id", "")) for record in records if str(record.get("run_id", "")).strip()})
+    source_event_ids = sorted(
+        {
+            str(event_id).strip()
+            for record in records
+            for event_id in list(record.get("source_event_ids", []))
+            if str(event_id).strip()
+        }
+    )
+    source_event_digest = hashlib.sha256(json.dumps(source_event_ids, sort_keys=True).encode("utf-8")).hexdigest()
     return {
         "dataset_version": DATASET_VERSION,
         "purpose": purpose,
@@ -146,5 +165,7 @@ def build_dataset_manifest(
         "record_count": len(records),
         "run_count": len(run_ids),
         "run_ids": run_ids,
+        "source_event_count": len(source_event_ids),
+        "source_event_ids_sha256": source_event_digest,
         "sha256": digest,
     }

--- a/python/helpers/governance_dataset_quality.py
+++ b/python/helpers/governance_dataset_quality.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def score_episode(events: list[dict[str, Any]]) -> dict[str, Any]:
+    event_types = [str(event.get("type", "")).strip().lower() for event in events]
+    has_success_outcome = any(
+        event_type == "run.outcome" and str(event.get("outcome", "")).strip().lower() == "success"
+        for event_type, event in zip(event_types, events)
+    )
+    has_approved = any(
+        event_type == "approval.resolved" and str(event.get("status", "")).strip().lower() == "approved"
+        for event_type, event in zip(event_types, events)
+    )
+    has_denied = any(
+        event_type == "approval.resolved" and str(event.get("status", "")).strip().lower() in {"denied", "reject", "rejected"}
+        for event_type, event in zip(event_types, events)
+    )
+    parse_failures = sum(1 for event_type in event_types if event_type == "llm.response.parse_failed")
+    policy_denies = sum(
+        1
+        for event_type, event in zip(event_types, events)
+        if event_type == "policy.check.decision" and str(event.get("decision", "")).strip().lower() == "deny"
+    )
+
+    score = 0.0
+    if has_success_outcome:
+        score += 0.45
+    if has_approved:
+        score += 0.35
+    if not has_denied:
+        score += 0.10
+    score += max(0.0, 0.10 - 0.05 * float(parse_failures))
+    score -= 0.10 * float(policy_denies)
+    score = max(0.0, min(1.0, round(score, 6)))
+
+    tier = "audit_only"
+    train_eligible = score >= 0.65
+    gold = score >= 0.85 and has_approved and has_success_outcome and parse_failures == 0 and policy_denies == 0
+    if gold:
+        tier = "gold"
+    elif train_eligible:
+        tier = "tier2"
+    else:
+        tier = "tier1"
+
+    return {
+        "quality_score": score,
+        "train_eligible": train_eligible,
+        "gold": gold,
+        "tier": tier,
+        "signals": {
+            "has_success_outcome": has_success_outcome,
+            "has_approved": has_approved,
+            "has_denied": has_denied,
+            "parse_failures": parse_failures,
+            "policy_denies": policy_denies,
+        },
+    }
+

--- a/python/helpers/governance_gate.py
+++ b/python/helpers/governance_gate.py
@@ -154,6 +154,9 @@ def emit_governance_runtime_event(agent: Any, event: dict[str, Any]) -> None:
     _emit_run_started_once(agent, project_name)
     enriched = dict(event or {})
     enriched.setdefault("project_name", project_name)
+    # Runtime events are emitted by the agent execution path (not policy engine).
+    enriched.setdefault("actor_id", "actor_agent_runtime")
+    enriched.setdefault("actor_type", "agent")
     _emit_governance_event(agent, enriched)
 
 

--- a/tests/test_agent_misformat_guard.py
+++ b/tests/test_agent_misformat_guard.py
@@ -17,11 +17,15 @@ class _DummyContext:
     def __init__(self) -> None:
         self.log = _DummyLog()
 
+    def get_data(self, _key):
+        return None
+
 
 def _build_agent_for_process_tools() -> Agent:
     agent = Agent.__new__(Agent)
     agent.data = {}
     agent.agent_name = "A0"
+    agent.loop_data = None
     agent.context = _DummyContext()
     agent.read_prompt = lambda _name: "misformat"
     agent.hist_add_warning = lambda _msg: None

--- a/tests/test_governance_api_phase2.py
+++ b/tests/test_governance_api_phase2.py
@@ -196,6 +196,64 @@ def test_training_candidates_filter_and_export(monkeypatch):
     assert "candidate_id" in csv_resp.get_data(as_text=True)
 
 
+def test_training_candidates_consent_aware_exports(monkeypatch):
+    import python.api.training_candidates as mod
+
+    handler = TrainingCandidates(None, threading.Lock())
+    events = [
+        {
+            "type": "approval.resolved",
+            "status": "approved",
+            "project_name": "p1",
+            "run_id": "r1",
+            "created_at": "2026-02-17T10:01:00+00:00",
+            "tool_name": "code_execution_tool",
+            "consent_scope": "eval_allowed",
+        },
+        {
+            "type": "approval.resolved",
+            "status": "approved",
+            "project_name": "p1",
+            "run_id": "r2",
+            "created_at": "2026-02-17T10:02:00+00:00",
+            "tool_name": "code_execution_tool",
+            "consent_scope": "training_allowed",
+        },
+        {
+            "type": "approval.resolved",
+            "status": "approved",
+            "project_name": "p1",
+            "run_id": "r3",
+            "created_at": "2026-02-17T10:03:00+00:00",
+            "tool_name": "code_execution_tool",
+            "consent_scope": "audit_only",
+        },
+    ]
+    monkeypatch.setattr(mod, "load_governance_events", lambda project_name=None, limit=200: events)
+
+    eval_export = __import__("asyncio").run(
+        handler.process(
+            {"project_name": "p1", "export_format": "jsonl", "export_purpose": "eval", "limit": 10},
+            _DummyRequest("POST"),
+        )
+    )
+    eval_body = eval_export.get_data(as_text=True)
+    assert "r1" in eval_body
+    assert "r2" in eval_body
+    assert "r3" not in eval_body
+
+    training_export = __import__("asyncio").run(
+        handler.process(
+            {"project_name": "p1", "export_format": "jsonl", "export_purpose": "training", "limit": 10},
+            _DummyRequest("POST"),
+        )
+    )
+    training_body = training_export.get_data(as_text=True)
+    assert "r2" in training_body
+    assert "r1" not in training_body
+    assert "r3" not in training_body
+
+
 def test_system_trace_scaffold_contract():
     handler = SystemTrace(None, threading.Lock())
     out = __import__("asyncio").run(handler.process({}, _DummyRequest("POST")))

--- a/tests/test_governance_dataset_builder.py
+++ b/tests/test_governance_dataset_builder.py
@@ -10,6 +10,7 @@ def test_build_episode_records_groups_by_run_and_sorts_events():
     events = [
         {
             "type": "run.outcome",
+            "event_id": "evt-002",
             "run_id": "run-b",
             "project_name": "p1",
             "created_at": "2026-02-18T10:02:00+00:00",
@@ -18,6 +19,7 @@ def test_build_episode_records_groups_by_run_and_sorts_events():
         },
         {
             "type": "run.started",
+            "event_id": "evt-001",
             "run_id": "run-b",
             "project_name": "p1",
             "created_at": "2026-02-18T10:01:00+00:00",
@@ -39,6 +41,7 @@ def test_build_episode_records_groups_by_run_and_sorts_events():
     assert records[1]["run_id"] == "run-b"
     assert records[1]["events"][0]["type"] == "run.started"
     assert records[1]["events"][1]["type"] == "run.outcome"
+    assert records[1]["source_event_ids"] == ["evt-001", "evt-002"]
     assert "quality_score" in records[1]["labels"]
     assert "train_eligible" in records[1]["labels"]
     assert "gold" in records[1]["labels"]
@@ -87,6 +90,7 @@ def test_build_dataset_manifest_is_deterministic():
             "purpose": "eval",
             "labels": {"outcome": "unknown", "event_count": 1},
             "quality": {"quality_score": 0.5, "train_eligible": False, "gold": False, "tier": "tier1"},
+            "source_event_ids": ["evt-100"],
             "events": [{"type": "run.started", "run_id": "run-a"}],
         }
     ]
@@ -95,4 +99,17 @@ def test_build_dataset_manifest_is_deterministic():
     assert manifest["record_count"] == 1
     assert manifest["run_count"] == 1
     assert manifest["run_ids"] == ["run-a"]
+    assert manifest["source_event_count"] == 1
+    assert len(str(manifest["source_event_ids_sha256"])) == 64
     assert len(str(manifest["sha256"])) == 64
+
+
+def test_build_episode_records_generates_stable_source_ids_without_event_id():
+    events = [
+        {"type": "run.started", "run_id": "run-c", "created_at": "2026-02-18T09:00:00+00:00", "consent_scope": "eval_allowed"},
+        {"type": "run.outcome", "run_id": "run-c", "created_at": "2026-02-18T09:01:00+00:00", "consent_scope": "eval_allowed"},
+    ]
+    first = build_episode_records(events, purpose="eval")[0]["source_event_ids"]
+    second = build_episode_records(events, purpose="eval")[0]["source_event_ids"]
+    assert first == second
+    assert all(str(item).startswith("ev_") for item in first)

--- a/tests/test_governance_dataset_builder.py
+++ b/tests/test_governance_dataset_builder.py
@@ -1,0 +1,72 @@
+from python.helpers.governance_dataset_builder import (
+    DATASET_VERSION,
+    build_episode_records,
+    episode_records_to_jsonl,
+)
+
+
+def test_build_episode_records_groups_by_run_and_sorts_events():
+    events = [
+        {
+            "type": "run.outcome",
+            "run_id": "run-b",
+            "project_name": "p1",
+            "created_at": "2026-02-18T10:02:00+00:00",
+            "outcome": "success",
+            "consent_scope": "training_allowed",
+        },
+        {
+            "type": "run.started",
+            "run_id": "run-b",
+            "project_name": "p1",
+            "created_at": "2026-02-18T10:01:00+00:00",
+            "consent_scope": "training_allowed",
+        },
+        {
+            "type": "run.started",
+            "run_id": "run-a",
+            "project_name": "p0",
+            "created_at": "2026-02-18T09:00:00+00:00",
+            "consent_scope": "eval_allowed",
+        },
+    ]
+
+    records = build_episode_records(events, purpose="eval")
+    assert len(records) == 2
+    assert records[0]["dataset_version"] == DATASET_VERSION
+    assert records[0]["run_id"] == "run-a"
+    assert records[1]["run_id"] == "run-b"
+    assert records[1]["events"][0]["type"] == "run.started"
+    assert records[1]["events"][1]["type"] == "run.outcome"
+
+
+def test_build_episode_records_applies_consent_by_purpose():
+    events = [
+        {"type": "run.started", "run_id": "a", "consent_scope": "audit_only"},
+        {"type": "run.started", "run_id": "b", "consent_scope": "eval_allowed"},
+        {"type": "run.started", "run_id": "c", "consent_scope": "training_allowed"},
+    ]
+
+    eval_records = build_episode_records(events, purpose="eval")
+    train_records = build_episode_records(events, purpose="training")
+
+    assert [record["run_id"] for record in eval_records] == ["b", "c"]
+    assert [record["run_id"] for record in train_records] == ["c"]
+
+
+def test_episode_records_to_jsonl_is_deterministic():
+    records = [
+        {
+            "dataset_version": DATASET_VERSION,
+            "episode_id": "ep_x",
+            "run_id": "run-x",
+            "project_name": "p1",
+            "consent_scope": "eval_allowed",
+            "purpose": "eval",
+            "labels": {"outcome": "unknown", "event_count": 1},
+            "events": [{"type": "run.started", "run_id": "run-x"}],
+        }
+    ]
+    payload = episode_records_to_jsonl(records)
+    assert payload.count("\n") == 1
+    assert "\"episode_id\": \"ep_x\"" in payload

--- a/tests/test_governance_dataset_builder.py
+++ b/tests/test_governance_dataset_builder.py
@@ -1,5 +1,6 @@
 from python.helpers.governance_dataset_builder import (
     DATASET_VERSION,
+    build_dataset_manifest,
     build_episode_records,
     episode_records_to_jsonl,
 )
@@ -73,3 +74,25 @@ def test_episode_records_to_jsonl_is_deterministic():
     payload = episode_records_to_jsonl(records)
     assert payload.count("\n") == 1
     assert "\"episode_id\": \"ep_x\"" in payload
+
+
+def test_build_dataset_manifest_is_deterministic():
+    records = [
+        {
+            "dataset_version": DATASET_VERSION,
+            "episode_id": "ep_a",
+            "run_id": "run-a",
+            "project_name": "p1",
+            "consent_scope": "eval_allowed",
+            "purpose": "eval",
+            "labels": {"outcome": "unknown", "event_count": 1},
+            "quality": {"quality_score": 0.5, "train_eligible": False, "gold": False, "tier": "tier1"},
+            "events": [{"type": "run.started", "run_id": "run-a"}],
+        }
+    ]
+    manifest = build_dataset_manifest(records, purpose="eval", project_name="p1")
+    assert manifest["dataset_version"] == DATASET_VERSION
+    assert manifest["record_count"] == 1
+    assert manifest["run_count"] == 1
+    assert manifest["run_ids"] == ["run-a"]
+    assert len(str(manifest["sha256"])) == 64

--- a/tests/test_governance_dataset_builder.py
+++ b/tests/test_governance_dataset_builder.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from python.helpers.governance_dataset_builder import (
     DATASET_VERSION,
     build_dataset_manifest,
@@ -89,7 +91,7 @@ def test_build_dataset_manifest_is_deterministic():
             "consent_scope": "eval_allowed",
             "purpose": "eval",
             "labels": {"outcome": "unknown", "event_count": 1},
-            "quality": {"quality_score": 0.5, "train_eligible": False, "gold": False, "tier": "tier1"},
+            "quality": {"quality_score": 0.5, "train_eligible": True, "gold": True, "tier": "gold"},
             "source_event_ids": ["evt-100"],
             "events": [{"type": "run.started", "run_id": "run-a"}],
         }
@@ -99,8 +101,11 @@ def test_build_dataset_manifest_is_deterministic():
     assert manifest["record_count"] == 1
     assert manifest["run_count"] == 1
     assert manifest["run_ids"] == ["run-a"]
+    assert manifest["train_eligible_count"] == 1
+    assert manifest["gold_count"] == 1
     assert manifest["source_event_count"] == 1
     assert len(str(manifest["source_event_ids_sha256"])) == 64
+    assert dt.datetime.fromisoformat(str(manifest["generated_at"]))
     assert len(str(manifest["sha256"])) == 64
 
 

--- a/tests/test_governance_dataset_builder.py
+++ b/tests/test_governance_dataset_builder.py
@@ -38,6 +38,9 @@ def test_build_episode_records_groups_by_run_and_sorts_events():
     assert records[1]["run_id"] == "run-b"
     assert records[1]["events"][0]["type"] == "run.started"
     assert records[1]["events"][1]["type"] == "run.outcome"
+    assert "quality_score" in records[1]["labels"]
+    assert "train_eligible" in records[1]["labels"]
+    assert "gold" in records[1]["labels"]
 
 
 def test_build_episode_records_applies_consent_by_purpose():

--- a/tests/test_governance_dataset_export.py
+++ b/tests/test_governance_dataset_export.py
@@ -1,0 +1,81 @@
+import json
+import sys
+from pathlib import Path
+
+import tools.governance_dataset_export as export_mod
+
+
+def _run_export(monkeypatch, tmp_path: Path, purpose: str) -> tuple[list[dict], dict]:
+    events = [
+        {
+            "type": "run.started",
+            "event_id": "evt-a",
+            "run_id": "run-a",
+            "project_name": "proj",
+            "created_at": "2026-02-18T10:00:00+00:00",
+            "consent_scope": "audit_only",
+        },
+        {
+            "type": "run.started",
+            "event_id": "evt-b",
+            "run_id": "run-b",
+            "project_name": "proj",
+            "created_at": "2026-02-18T10:01:00+00:00",
+            "consent_scope": "eval_allowed",
+        },
+        {
+            "type": "run.started",
+            "event_id": "evt-c",
+            "run_id": "run-c",
+            "project_name": "proj",
+            "created_at": "2026-02-18T10:02:00+00:00",
+            "consent_scope": "training_allowed",
+        },
+    ]
+    monkeypatch.setattr(export_mod, "load_governance_events", lambda **kwargs: events)
+
+    output = tmp_path / f"{purpose}.jsonl"
+    manifest = tmp_path / f"{purpose}.manifest.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "governance_dataset_export.py",
+            "--project-name",
+            "proj",
+            "--purpose",
+            purpose,
+            "--output",
+            str(output),
+            "--manifest-output",
+            str(manifest),
+        ],
+    )
+    rc = export_mod.main()
+    assert rc == 0
+
+    rows = [
+        json.loads(line)
+        for line in output.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+    return rows, manifest_payload
+
+
+def test_dataset_export_eval_respects_consent_and_lineage(monkeypatch, tmp_path: Path):
+    rows, manifest = _run_export(monkeypatch, tmp_path, purpose="eval")
+    assert [row["run_id"] for row in rows] == ["run-b", "run-c"]
+    assert rows[0]["source_event_ids"] == ["evt-b"]
+    assert rows[1]["source_event_ids"] == ["evt-c"]
+    assert manifest["purpose"] == "eval"
+    assert manifest["source_event_count"] == 2
+    assert len(str(manifest["source_event_ids_sha256"])) == 64
+
+
+def test_dataset_export_training_respects_consent(monkeypatch, tmp_path: Path):
+    rows, manifest = _run_export(monkeypatch, tmp_path, purpose="training")
+    assert [row["run_id"] for row in rows] == ["run-c"]
+    assert rows[0]["source_event_ids"] == ["evt-c"]
+    assert manifest["purpose"] == "training"
+    assert manifest["record_count"] == 1

--- a/tests/test_governance_dataset_quality.py
+++ b/tests/test_governance_dataset_quality.py
@@ -1,0 +1,28 @@
+from python.helpers.governance_dataset_quality import score_episode
+
+
+def test_score_episode_gold_path():
+    events = [
+        {"type": "run.started"},
+        {"type": "approval.resolved", "status": "approved"},
+        {"type": "run.outcome", "outcome": "success"},
+    ]
+    out = score_episode(events)
+    assert out["quality_score"] >= 0.85
+    assert out["train_eligible"] is True
+    assert out["gold"] is True
+    assert out["tier"] == "gold"
+
+
+def test_score_episode_penalizes_parse_failures_and_denies():
+    events = [
+        {"type": "policy.check.decision", "decision": "deny"},
+        {"type": "llm.response.parse_failed"},
+        {"type": "approval.resolved", "status": "denied"},
+        {"type": "run.outcome", "outcome": "failure"},
+    ]
+    out = score_episode(events)
+    assert out["quality_score"] < 0.65
+    assert out["train_eligible"] is False
+    assert out["gold"] is False
+    assert out["tier"] in {"tier1", "audit_only"}

--- a/tests/test_governance_dataset_retention.py
+++ b/tests/test_governance_dataset_retention.py
@@ -42,3 +42,16 @@ def test_apply_retention_deletes_old_artifacts(tmp_path: Path):
     assert not old_jsonl.exists()
     assert not old_manifest.exists()
     assert fresh_manifest.exists()
+
+
+def test_apply_retention_ignores_non_dataset_json_files(tmp_path: Path):
+    old_misc = tmp_path / "misc" / "notes.json"
+    old_manifest = tmp_path / "misc" / "dataset.manifest.json"
+    _touch_with_age(old_misc, days_old=30)
+    _touch_with_age(old_manifest, days_old=30)
+
+    result = apply_retention(tmp_path, max_age_days=7, dry_run=False)
+    assert result["checked"] == 1
+    assert result["deleted"] == ["misc/dataset.manifest.json"]
+    assert old_misc.exists()
+    assert not old_manifest.exists()

--- a/tests/test_governance_dataset_retention.py
+++ b/tests/test_governance_dataset_retention.py
@@ -1,0 +1,44 @@
+import datetime as dt
+import os
+from pathlib import Path
+
+from tools.governance_dataset_retention import apply_retention
+
+
+def _touch_with_age(path: Path, *, days_old: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x\n", encoding="utf-8")
+    ts = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days_old)).timestamp()
+    os.utime(path, (ts, ts))
+
+
+def test_apply_retention_dry_run_reports_without_deleting(tmp_path: Path):
+    old_file = tmp_path / "exports" / "old.jsonl"
+    new_file = tmp_path / "exports" / "new.jsonl"
+    _touch_with_age(old_file, days_old=10)
+    _touch_with_age(new_file, days_old=1)
+
+    result = apply_retention(tmp_path, max_age_days=7, dry_run=True)
+    assert result["checked"] == 2
+    assert "exports/old.jsonl" in result["deleted"]
+    assert "exports/new.jsonl" in result["retained"]
+    assert old_file.exists()
+    assert new_file.exists()
+
+
+def test_apply_retention_deletes_old_artifacts(tmp_path: Path):
+    old_jsonl = tmp_path / "batch-a" / "dataset.jsonl"
+    old_manifest = tmp_path / "batch-a" / "dataset.manifest.json"
+    fresh_manifest = tmp_path / "batch-b" / "dataset.manifest.json"
+    _touch_with_age(old_jsonl, days_old=30)
+    _touch_with_age(old_manifest, days_old=30)
+    _touch_with_age(fresh_manifest, days_old=2)
+
+    result = apply_retention(tmp_path, max_age_days=7, dry_run=False)
+    assert sorted(result["deleted"]) == sorted(
+        ["batch-a/dataset.jsonl", "batch-a/dataset.manifest.json"]
+    )
+    assert result["retained"] == ["batch-b/dataset.manifest.json"]
+    assert not old_jsonl.exists()
+    assert not old_manifest.exists()
+    assert fresh_manifest.exists()

--- a/tests/test_governance_input.py
+++ b/tests/test_governance_input.py
@@ -285,7 +285,9 @@ def test_emit_governance_runtime_event_only_when_enabled(monkeypatch):
     )
 
     assert any(e.get("type") == "run.started" for e in events)
-    assert any(e.get("type") == "llm.response.parsed" for e in events)
+    runtime_event = next(e for e in events if e.get("type") == "llm.response.parsed")
+    assert runtime_event["actor_id"] == "actor_agent_runtime"
+    assert runtime_event["actor_type"] == "agent"
 
     events.clear()
     monkeypatch.setattr(

--- a/tests/test_governance_training_trigger.py
+++ b/tests/test_governance_training_trigger.py
@@ -1,0 +1,74 @@
+import datetime as dt
+
+from tools.governance_training_trigger import evaluate_training_trigger
+
+
+def _iso(days_ago: int) -> str:
+    return (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days_ago)).isoformat()
+
+
+def test_evaluate_training_trigger_emits_true_when_thresholds_met():
+    manifests = [
+        {
+            "purpose": "training",
+            "generated_at": _iso(1),
+            "record_count": 150,
+            "gold_count": 30,
+            "sha256": "abc",
+            "_path": "/tmp/a.manifest.json",
+        },
+        {
+            "purpose": "training",
+            "generated_at": _iso(1),
+            "record_count": 120,
+            "gold_count": 25,
+            "sha256": "def",
+            "_path": "/tmp/b.manifest.json",
+        },
+    ]
+    out = evaluate_training_trigger(
+        manifests,
+        min_record_count=200,
+        min_gold_count=50,
+        max_manifest_age_days=7,
+    )
+    assert out["trigger_training"] is True
+    assert out["eligible_manifests"] == 2
+    assert out["total_records"] == 270
+    assert out["total_gold"] == 55
+
+
+def test_evaluate_training_trigger_ignores_stale_and_eval_manifests():
+    manifests = [
+        {
+            "purpose": "eval",
+            "generated_at": _iso(1),
+            "record_count": 1000,
+            "gold_count": 1000,
+            "_path": "/tmp/eval.manifest.json",
+        },
+        {
+            "purpose": "training",
+            "generated_at": _iso(30),
+            "record_count": 1000,
+            "gold_count": 1000,
+            "_path": "/tmp/stale.manifest.json",
+        },
+        {
+            "purpose": "training",
+            "generated_at": _iso(1),
+            "record_count": 30,
+            "gold_count": 2,
+            "_path": "/tmp/fresh.manifest.json",
+        },
+    ]
+    out = evaluate_training_trigger(
+        manifests,
+        min_record_count=100,
+        min_gold_count=10,
+        max_manifest_age_days=7,
+    )
+    assert out["trigger_training"] is False
+    assert out["eligible_manifests"] == 1
+    assert out["total_records"] == 30
+    assert out["total_gold"] == 2

--- a/tests/test_governance_user_message_events.py
+++ b/tests/test_governance_user_message_events.py
@@ -7,7 +7,7 @@ def _build_agent_for_user_message() -> Agent:
     agent = Agent.__new__(Agent)
     agent.history = type("_History", (), {"new_topic": lambda self: None})()
     agent.parse_prompt = lambda *_args, **_kwargs: {"message": "ok"}
-    agent.hist_add_message = lambda _ai, _content, tokens=0: {"id": "m1", "tokens": tokens}
+    agent.hist_add_message = lambda _ai, content=None, tokens=0, **_kwargs: {"id": "m1", "content": content, "tokens": tokens}
     agent.last_user_message = None
     return agent
 
@@ -37,4 +37,3 @@ def test_hist_add_user_message_emits_user_message_created(monkeypatch):
     assert event["attachments_count"] == 2
     assert event["system_message_count"] == 1
     assert event["intervention"] is False
-

--- a/tools/governance_audit_query_pack.py
+++ b/tools/governance_audit_query_pack.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+
+from python.governance_runtime.db import connection
+from python.governance_runtime.repos import GovernancePostgresRepo
+
+
+def _fail(msg: str) -> int:
+    print(json.dumps({"ok": False, "error": msg}))
+    return 1
+
+
+def _seed_events(run_id: str) -> None:
+    repo = GovernancePostgresRepo()
+    repo.append_event(
+        {
+            "type": "run.started",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 1,
+            "actor_id": "actor_agent_runtime",
+            "actor_type": "agent",
+        }
+    )
+    repo.append_event(
+        {
+            "type": "tool.contract.validation",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 2,
+            "tool_name": "github.create_pr",
+            "contract_id": "gh.create_pr.v3",
+            "passed": False,
+            "actor_id": "actor_agent_runtime",
+            "actor_type": "agent",
+        }
+    )
+    repo.append_event(
+        {
+            "type": "approval.requested",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 3,
+            "actor_id": "actor_policy_engine",
+            "actor_type": "policy",
+        }
+    )
+    repo.append_event(
+        {
+            "type": "approval.resolved",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 4,
+            "decision": "approved",
+            "actor_id": "actor_human_operator",
+            "actor_type": "human_user",
+        }
+    )
+    repo.append_event(
+        {
+            "type": "run.outcome",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 5,
+            "outcome": "success",
+            "labels": {"tier": "gold"},
+            "actor_id": "actor_agent_runtime",
+            "actor_type": "agent",
+        }
+    )
+
+
+def main() -> int:
+    if str(os.environ.get("GOV_PERSIST_BACKEND", "")).strip().lower() != "postgres":
+        return _fail("GOV_PERSIST_BACKEND must be postgres")
+
+    run_id = "22222222-2222-2222-2222-222222222222"
+    _seed_events(run_id)
+
+    with connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM (
+                  SELECT
+                    run_id,
+                    MIN(observed_at) FILTER (WHERE event_type='approval.requested') AS requested_at,
+                    MIN(observed_at) FILTER (WHERE event_type='approval.resolved') AS resolved_at
+                  FROM governance.audit_events
+                  WHERE tenant_id='tenant_default'
+                  GROUP BY run_id
+                ) x
+                WHERE requested_at IS NOT NULL
+                  AND resolved_at IS NOT NULL
+                  AND resolved_at >= requested_at
+                """
+            )
+            approval_latency_rows = int(cur.fetchone()[0] or 0)
+
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM governance.audit_events
+                WHERE event_type = 'tool.contract.validation'
+                  AND COALESCE(payload_json->>'passed', 'true') = 'false'
+                """
+            )
+            contract_violations = int(cur.fetchone()[0] or 0)
+
+            cur.execute(
+                """
+                SELECT
+                  COUNT(*) FILTER (WHERE event_type='run.outcome') AS runs,
+                  COUNT(*) FILTER (
+                    WHERE event_type='run.outcome'
+                      AND COALESCE(payload_json->'labels'->>'tier', '') IN ('tier2', 'gold')
+                  ) AS train_eligible,
+                  COUNT(*) FILTER (
+                    WHERE event_type='run.outcome'
+                      AND COALESCE(payload_json->'labels'->>'tier', '') = 'gold'
+                  ) AS gold
+                FROM governance.audit_events
+                """
+            )
+            runs, train_eligible, gold = cur.fetchone()
+            runs = int(runs or 0)
+            train_eligible = int(train_eligible or 0)
+            gold = int(gold or 0)
+
+    ok = approval_latency_rows >= 1 and contract_violations >= 1 and runs >= 1 and train_eligible >= 1 and gold >= 1
+    print(
+        json.dumps(
+            {
+                "ok": ok,
+                "run_id": run_id,
+                "approval_latency_rows": approval_latency_rows,
+                "contract_violations": contract_violations,
+                "runs": runs,
+                "train_eligible": train_eligible,
+                "gold": gold,
+            }
+        )
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance_audit_smoke.py
+++ b/tools/governance_audit_smoke.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from python.governance_runtime.db import connection
+from python.governance_runtime.repos import GovernancePostgresRepo
+
+
+def _fail(msg: str) -> int:
+    print(json.dumps({"ok": False, "error": msg}))
+    return 1
+
+
+def main() -> int:
+    if str(os.environ.get("GOV_PERSIST_BACKEND", "")).strip().lower() != "postgres":
+        return _fail("GOV_PERSIST_BACKEND must be postgres")
+
+    repo = GovernancePostgresRepo()
+    run_id = "11111111-1111-1111-1111-111111111111"
+    repo.append_event(
+        {
+            "type": "run.started",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 1,
+            "actor_id": "actor_agent_runtime",
+            "actor_type": "agent",
+        }
+    )
+    repo.append_event(
+        {
+            "type": "policy.check.decision",
+            "run_id": run_id,
+            "thread_id": run_id,
+            "sequence_number": 2,
+            "decision": "allow",
+            "reason_codes": ["policy.allowed"],
+            "actor_id": "actor_policy_engine",
+            "actor_type": "policy",
+        }
+    )
+
+    with connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM governance.audit_events WHERE run_id = %s",
+                (run_id,),
+            )
+            total_events = int(cur.fetchone()[0] or 0)
+
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM governance.audit_events
+                WHERE run_id = %s AND (
+                    actor_id IS NULL OR actor_id = '' OR actor_type IS NULL OR actor_type = ''
+                )
+                """,
+                (run_id,),
+            )
+            missing_actor = int(cur.fetchone()[0] or 0)
+
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM governance.audit_events
+                WHERE run_id = %s
+                  AND contains_secrets = true
+                  AND payload_json NOT IN ('{}'::jsonb, '{"suppressed": true}'::jsonb)
+                """,
+                (run_id,),
+            )
+            unsuppressed_secret_payloads = int(cur.fetchone()[0] or 0)
+
+            cur.execute(
+                """
+                WITH ordered AS (
+                  SELECT sequence_number, prev_event_hash,
+                         LAG(event_hash) OVER (ORDER BY sequence_number) AS prev_expected
+                  FROM governance.audit_events
+                  WHERE tenant_id = 'tenant_default' AND run_id = %s
+                )
+                SELECT COUNT(*)
+                FROM ordered
+                WHERE sequence_number > 1 AND prev_event_hash <> prev_expected
+                """,
+                (run_id,),
+            )
+            chain_breaks = int(cur.fetchone()[0] or 0)
+
+    ok = (
+        total_events >= 2
+        and missing_actor == 0
+        and unsuppressed_secret_payloads == 0
+        and chain_breaks == 0
+    )
+    print(
+        json.dumps(
+            {
+                "ok": ok,
+                "run_id": run_id,
+                "total_events": total_events,
+                "missing_actor": missing_actor,
+                "unsuppressed_secret_payloads": unsuppressed_secret_payloads,
+                "chain_breaks": chain_breaks,
+            }
+        )
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance_dataset_export.py
+++ b/tools/governance_dataset_export.py
@@ -2,9 +2,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import pathlib
 
-from python.helpers.governance_dataset_builder import build_episode_records, episode_records_to_jsonl
+from python.helpers.governance_dataset_builder import (
+    build_dataset_manifest,
+    build_episode_records,
+    episode_records_to_jsonl,
+)
 from python.helpers.governance_gate import load_governance_events
 
 
@@ -14,6 +19,7 @@ def main() -> int:
     parser.add_argument("--purpose", default="eval", choices=["eval", "training"], help="Dataset export purpose.")
     parser.add_argument("--limit", type=int, default=10000, help="Max governance events to read.")
     parser.add_argument("--output", required=True, help="Output JSONL file path.")
+    parser.add_argument("--manifest-output", default="", help="Optional output JSON path for dataset manifest.")
     args = parser.parse_args()
 
     project_name = str(args.project_name).strip() or None
@@ -22,6 +28,12 @@ def main() -> int:
     output = pathlib.Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(episode_records_to_jsonl(records), encoding="utf-8")
+    manifest_output = str(args.manifest_output).strip()
+    if manifest_output:
+        manifest = build_dataset_manifest(records, purpose=str(args.purpose), project_name=project_name)
+        manifest_path = pathlib.Path(manifest_output)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     print(f"exported {len(records)} episodes to {output}")
     return 0
 

--- a/tools/governance_dataset_export.py
+++ b/tools/governance_dataset_export.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+from python.helpers.governance_dataset_builder import build_episode_records, episode_records_to_jsonl
+from python.helpers.governance_gate import load_governance_events
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export governed runs into canonical episode JSONL records.")
+    parser.add_argument("--project-name", default="", help="Optional governance project name filter.")
+    parser.add_argument("--purpose", default="eval", choices=["eval", "training"], help="Dataset export purpose.")
+    parser.add_argument("--limit", type=int, default=10000, help="Max governance events to read.")
+    parser.add_argument("--output", required=True, help="Output JSONL file path.")
+    args = parser.parse_args()
+
+    project_name = str(args.project_name).strip() or None
+    events = load_governance_events(project_name=project_name, limit=max(1, int(args.limit)))
+    records = build_episode_records(events, purpose=str(args.purpose))
+    output = pathlib.Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(episode_records_to_jsonl(records), encoding="utf-8")
+    print(f"exported {len(records)} episodes to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance_dataset_retention.py
+++ b/tools/governance_dataset_retention.py
@@ -12,6 +12,15 @@ def _utc_now() -> dt.datetime:
     return dt.datetime.now(dt.timezone.utc)
 
 
+def _is_dataset_artifact(path: pathlib.Path) -> bool:
+    name = path.name.lower()
+    if name.endswith(".jsonl"):
+        return True
+    if name.endswith(".manifest.json"):
+        return True
+    return False
+
+
 def apply_retention(
     datasets_dir: pathlib.Path,
     *,
@@ -38,7 +47,7 @@ def apply_retention(
     for path in sorted(datasets_dir.glob("**/*")):
         if not path.is_file():
             continue
-        if path.suffix not in {".jsonl", ".json"}:
+        if not _is_dataset_artifact(path):
             continue
         checked += 1
         modified = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)

--- a/tools/governance_dataset_retention.py
+++ b/tools/governance_dataset_retention.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+from typing import Any
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def apply_retention(
+    datasets_dir: pathlib.Path,
+    *,
+    max_age_days: int,
+    dry_run: bool,
+) -> dict[str, Any]:
+    cutoff = _utc_now() - dt.timedelta(days=max(0, int(max_age_days)))
+    deleted: list[str] = []
+    retained: list[str] = []
+    checked = 0
+
+    if not datasets_dir.exists():
+        return {
+            "ok": True,
+            "datasets_dir": str(datasets_dir),
+            "max_age_days": max_age_days,
+            "dry_run": dry_run,
+            "cutoff": cutoff.isoformat(),
+            "checked": 0,
+            "deleted": [],
+            "retained": [],
+        }
+
+    for path in sorted(datasets_dir.glob("**/*")):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".jsonl", ".json"}:
+            continue
+        checked += 1
+        modified = dt.datetime.fromtimestamp(path.stat().st_mtime, tz=dt.timezone.utc)
+        rel = str(path.relative_to(datasets_dir))
+        if modified < cutoff:
+            deleted.append(rel)
+            if not dry_run:
+                path.unlink(missing_ok=True)
+        else:
+            retained.append(rel)
+
+    return {
+        "ok": True,
+        "datasets_dir": str(datasets_dir),
+        "max_age_days": max_age_days,
+        "dry_run": dry_run,
+        "cutoff": cutoff.isoformat(),
+        "checked": checked,
+        "deleted": deleted,
+        "retained": retained,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply retention policy to governed dataset artifacts (JSONL + manifests)."
+    )
+    parser.add_argument(
+        "--datasets-dir",
+        default="/a0/usr/governance/datasets",
+        help="Dataset artifacts directory.",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=30,
+        help="Delete files older than this many days.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report deletions without modifying files.",
+    )
+    args = parser.parse_args()
+
+    result = apply_retention(
+        pathlib.Path(args.datasets_dir),
+        max_age_days=max(0, int(args.max_age_days)),
+        dry_run=bool(args.dry_run),
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance_training_trigger.py
+++ b/tools/governance_training_trigger.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+from typing import Any
+
+
+def _parse_iso(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        return dt.datetime.fromisoformat(raw)
+    except Exception:
+        return None
+
+
+def _load_manifests(root: pathlib.Path) -> list[dict[str, Any]]:
+    manifests: list[dict[str, Any]] = []
+    if not root.exists():
+        return manifests
+    for path in sorted(root.glob("**/*.manifest.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        payload["_path"] = str(path)
+        manifests.append(payload)
+    return manifests
+
+
+def evaluate_training_trigger(
+    manifests: list[dict[str, Any]],
+    *,
+    min_record_count: int,
+    min_gold_count: int,
+    max_manifest_age_days: int,
+) -> dict[str, Any]:
+    now = dt.datetime.now(dt.timezone.utc)
+    max_age = max(0, int(max_manifest_age_days))
+    cutoff = now - dt.timedelta(days=max_age)
+
+    eligible: list[dict[str, Any]] = []
+    for item in manifests:
+        if str(item.get("purpose", "")).strip().lower() != "training":
+            continue
+        created_at = _parse_iso(item.get("generated_at"))
+        if created_at is not None and created_at < cutoff:
+            continue
+        eligible.append(item)
+
+    total_records = sum(int(item.get("record_count", 0) or 0) for item in eligible)
+    total_gold = sum(int(item.get("gold_count", 0) or 0) for item in eligible)
+    should_trigger = total_records >= min_record_count and total_gold >= min_gold_count
+
+    return {
+        "ok": True,
+        "checked_manifests": len(manifests),
+        "eligible_manifests": len(eligible),
+        "total_records": total_records,
+        "total_gold": total_gold,
+        "min_record_count": min_record_count,
+        "min_gold_count": min_gold_count,
+        "max_manifest_age_days": max_age,
+        "trigger_training": should_trigger,
+        "manifests": [
+            {
+                "path": str(item.get("_path", "")),
+                "generated_at": item.get("generated_at"),
+                "record_count": int(item.get("record_count", 0) or 0),
+                "gold_count": int(item.get("gold_count", 0) or 0),
+                "sha256": item.get("sha256"),
+            }
+            for item in eligible
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate governed training dataset manifests and emit a deterministic training trigger decision."
+    )
+    parser.add_argument(
+        "--datasets-dir",
+        default="/a0/usr/governance/datasets",
+        help="Directory containing dataset manifest files.",
+    )
+    parser.add_argument("--min-record-count", type=int, default=2000, help="Minimum records required to trigger.")
+    parser.add_argument("--min-gold-count", type=int, default=200, help="Minimum gold records required to trigger.")
+    parser.add_argument(
+        "--max-manifest-age-days",
+        type=int,
+        default=14,
+        help="Maximum age of manifest to consider (days).",
+    )
+    parser.add_argument("--output", default="", help="Optional output path for trigger plan JSON.")
+    args = parser.parse_args()
+
+    manifests = _load_manifests(pathlib.Path(args.datasets_dir))
+    result = evaluate_training_trigger(
+        manifests,
+        min_record_count=max(0, int(args.min_record_count)),
+        min_gold_count=max(0, int(args.min_gold_count)),
+        max_manifest_age_days=max(0, int(args.max_manifest_age_days)),
+    )
+    output = str(args.output).strip()
+    if output:
+        path = pathlib.Path(output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(result, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- set default runtime event actor attribution to `actor_agent_runtime` / `agent`
- expand Docker e2e governance pytest subset coverage
- add governance audit smoke script and wire it into Docker e2e run

## Validation
- `./tools/e2e.sh` (32 passed + audit smoke ok)
- pre-commit governance checks
  - `python3 tools/governance_sentinel.py`
  - `PYTHONPATH=. pytest -q tests/test_governance_input.py tests/test_snapshot_schema_v1.py`
